### PR TITLE
chore: speed up compilation of tests

### DIFF
--- a/tests/logging.nim
+++ b/tests/logging.nim
@@ -1,5 +1,5 @@
 when not defined(nimscript):
-  import pkg/archivist/logutils
+  import pkg/chronicles
 
   proc ignoreLogging(level: LogLevel, message: LogOutputStr) =
     discard


### PR DESCRIPTION
no longer import libp2p indirectly for every test