### PR TITLE
docker: set bootstrap service url

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -11,7 +11,7 @@ fi
 
 # Network
 if [[ -n "${NETWORK}" ]]; then
-  BOOTSTRAP_SERVICE_URL=https://spr.example.com #TODO
+  BOOTSTRAP_SERVICE_URL="https://spr.archivist.storage"
   export BOOTSTRAP_NODE_FROM_URL="${BOOTSTRAP_NODE_FROM_URL:-${BOOTSTRAP_SERVICE_URL}/${NETWORK}}"
 fi
 


### PR DESCRIPTION
PR sets a `BOOTSTRAP_SERVICE_URL` to a [recently deployed service](https://github.com/durability-labs/archivist-spr) and now we can pass just a network name to simply configuration
```shell
docker run --rm \
  -e NETWORK=testnet \
  durabilitylabs/archivist-node:sha-b3d385f-dist-tests
```