### PR TITLE
chore(ci): disable nph suggestion comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,4 +49,4 @@ jobs:
           version: 0.6.1
           options: "archivist/ tests/"
           fail: true
-          suggest: true
+          suggest: false


### PR DESCRIPTION
Rationale: the comments on github issues are rather [spammy](https://github.com/durability-labs/archivist-node/pull/11#pullrequestreview-3238809526), and the ci already fails if formatting is incorrect.