### PR TITLE
fix: Missing view tag for canMarkProofAsMissing in marketplace.nim

### DIFF
--- a/archivist/contracts/market.nim
+++ b/archivist/contracts/market.nim
@@ -400,7 +400,7 @@ method canMarkProofAsMissing*(
 ): Future[bool] {.async: (raises: [CancelledError]).} =
   try:
     let overrides = CallOverrides(blockTag: some BlockTag.pending)
-    discard await market.contract.canMarkProofAsMissing(id, period, overrides)
+    await market.contract.canMarkProofAsMissing(id, period, overrides)
     return true
   except EthersError as e:
     trace "Proof cannot be marked as missing", msg = e.msg

--- a/archivist/contracts/marketplace.nim
+++ b/archivist/contracts/marketplace.nim
@@ -180,8 +180,9 @@ proc markProofAsMissing*(
 
 proc canMarkProofAsMissing*(
   marketplace: Marketplace, id: SlotId, period: uint64
-): Confirmable {.
+) {.
   contract,
+  view,
   errors: [
     Marketplace_SlotNotAcceptingProofs, Proofs_PeriodNotEnded,
     Proofs_ValidationTimedOut, Proofs_ProofNotMissing, Proofs_ProofNotRequired,


### PR DESCRIPTION
During testing, found that contract function CanMarkProofAsMissing was found inside block transactions. This is a view function and should never end up on-chain. It increases costs for the validator greatly.

This fixes it by marking it as a view function.
I checked the other view functions, they're all correct.
I found that the contract defines a `slotProbability` function that appears to be never used. Can remove maybe?

