### PR TITLE
fix: Updates expiry of manifest-block

### DIFF
--- a/archivist/node.nim
+++ b/archivist/node.nim
@@ -136,6 +136,19 @@ proc fetchManifest*(
 
   return manifest.success
 
+proc fetchManifest*(
+    self: ArchivistNodeRef, cid: Cid, expiry: SecondsSince1970
+): Future[?!Manifest] {.async: (raises: [CancelledError]).} =
+  without manifest =? await self.fetchManifest(cid), error:
+    trace "Unable to fetch manifest for cid", cid
+    return failure(error)
+
+  if err =? (await self.networkStore.ensureExpiry(cid, expiry)).errorOption:
+    error "Failed to update manifest block expiry", cid, expiry
+    return failure(err)
+
+  return success(manifest)
+
 proc findPeer*(self: ArchivistNodeRef, peerId: PeerId): Future[?PeerRecord] {.async.} =
   ## Find peer using the discovery service from the given ArchivistNode
   ##
@@ -149,13 +162,9 @@ proc connect*(
 proc updateExpiry*(
     self: ArchivistNodeRef, manifestCid: Cid, expiry: SecondsSince1970
 ): Future[?!void] {.async: (raises: [CancelledError]).} =
-  without manifest =? await self.fetchManifest(manifestCid), error:
+  without manifest =? await self.fetchManifest(manifestCid, expiry), error:
     trace "Unable to fetch manifest for cid", manifestCid
     return failure(error)
-
-  if err =? (await self.networkStore.ensureExpiry(manifestCid, expiry)).errorOption:
-    error "Failed to update manifest block expiry", manifestCid, expiry
-    return failure(err)
 
   try:
     let ensuringFutures = Iter[int].new(0 ..< manifest.blocksCount).mapIt(
@@ -643,7 +652,7 @@ proc onStore(
 
   trace "Received a request to store a slot"
 
-  without manifest =? (await self.fetchManifest(cid)), err:
+  without manifest =? (await self.fetchManifest(cid, expiry)), err:
     trace "Unable to fetch manifest for cid", cid, err = err.msg
     return failure(err)
 

--- a/tests/archivist/node/testcontracts.nim
+++ b/tests/archivist/node/testcontracts.nim
@@ -126,7 +126,7 @@ asyncchecksuite "Test Node - Host contracts":
   test "onStore callback is set":
     check sales.onStore.isSome
 
-  test "onStore callback":
+  test "onStore callback should invoke onBlocks callback":
     let onStore = !sales.onStore
     var request = StorageRequest.example
     request.content.cid = verifiableBlock.cid
@@ -143,6 +143,19 @@ asyncchecksuite "Test Node - Host contracts":
     (await onStore(request, expiry, 1.uint64, onBlocks, isRepairing = false)).tryGet()
     check fetchedBytes == 12 * DefaultBlockSize.uint
 
+  test "onStore callback should update expiry for blocks":
+    let onStore = !sales.onStore
+    var request = StorageRequest.example
+    request.content.cid = verifiableBlock.cid
+    let expiry = (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix
+
+    let onBlocks = proc(
+        blocks: seq[bt.Block]
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
+      return success()
+
+    (await onStore(request, expiry, 1.uint64, onBlocks, isRepairing = false)).tryGet()
+
     let indexer = verifiable.verifiableStrategy.init(
       0, verifiable.blocksCount - 1, verifiable.numSlots
     )
@@ -155,3 +168,23 @@ asyncchecksuite "Test Node - Host contracts":
         blkMd = BlockMetadata.decode(bytes).tryGet
 
       check blkMd.expiry == expiry
+
+  test "onStore callback should update expiry for manifest":
+    let onStore = !sales.onStore
+    var request = StorageRequest.example
+    request.content.cid = verifiableBlock.cid
+    let expiry = (getTime() + DefaultBlockTtl.toTimesDuration + 1.hours).toUnix
+
+    let onBlocks = proc(
+        blocks: seq[bt.Block]
+    ): Future[?!void] {.async: (raises: [CancelledError]).} =
+      return success()
+
+    (await onStore(request, expiry, 1.uint64, onBlocks, isRepairing = false)).tryGet()
+
+    let
+      key = (createBlockExpirationMetadataKey(verifiableBlock.cid)).tryGet
+      bytes = (await localStoreMetaDs.get(key)).tryGet
+      manifestMd = BlockMetadata.decode(bytes).tryGet
+
+    check manifestMd.expiry == expiry


### PR DESCRIPTION
tldr: Manifest block expiries were not being updated correctly in the marketplace sales flow.

During testing we noticed that host-nodes would begin missing proofs if the original uploading node went offline immediately after the storage contract reaches started-state. Investigation revealed that they were unable to generate proofs because they did not have the manifest block. (And couldn't download it from the original uploader any more.) And they didn't have the manifest block because it has been removed by block maintenance long before the storage request would finish.

This PR makes sure fetched manifest blocks follow the same expiry as the data blocked, when they are being stored in relation to a storage contract.