### PR TITLE
ci(release): remove latest file after tagged releases upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,7 @@ jobs:
             aws s3 cp --recursive "${folder}" s3://${{ env.s3_bucket }}/releases/${branch} --endpoint-url ${{ env.s3_endpoint }}
             echo "${branch}" >  "${folder}"/latest
             aws s3 cp "${folder}"/latest s3://${{ env.s3_bucket }}/releases/latest --endpoint-url ${{ env.s3_endpoint }}
+            rm -f "${folder}"/latest
 
           # master branch
           elif [[ "${branch}" == "${{ github.event.repository.default_branch }}" ]]; then


### PR DESCRIPTION
During the latest release, it was observed that a file with the name `latest` is attached to the GitHub release artifacts.

We have to delete that file after release artifacts are uploaded to the cloud and before they are uploaded to the GitHub.