### PR TITLE
fix: Missing nullable flag for ethAddress

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,7 +44,6 @@ components:
 
     EthereumAddress:
       type: string
-      nullable: true
       description: Address of Ethereum address
 
     PricePerBytePerSecond:
@@ -171,6 +170,7 @@ components:
             $ref: "#/components/schemas/MultiAddress"
         ethAddress:
             $ref: "#/components/schemas/EthereumAddress"
+            nullable: true
         table:
           $ref: "#/components/schemas/PeersTable"
         archivist:


### PR DESCRIPTION
Fixes missing "Nullable: true" for ethAddress types in openapi.yaml.
