### PR TITLE
fix: incorrect newline replacement for windows platforms

### DIFF
--- a/archivist/conf.nim
+++ b/archivist/conf.nim
@@ -759,7 +759,8 @@ proc setupLogging*(conf: NodeConf) =
       var counter = 0.uint64
       proc numberedWriter(logLevel: LogLevel, msg: LogOutputStr) =
         inc(counter)
-        let withoutNewLine = msg[0 ..^ 2]
+        var withoutNewLine = $msg
+        withoutNewLine.removeSuffix
         writer(logLevel, withoutNewLine & " count=" & $counter & "\n")
 
       defaultChroniclesStream.outputs[0].writer = numberedWriter


### PR DESCRIPTION
Turns out strutils already has a func for this one.
