### PR TITLE
fix: flaky block maintenance test

### DIFF
--- a/tests/integration/1_minute/testblockmaintenance.nim
+++ b/tests/integration/1_minute/testblockmaintenance.nim
@@ -15,12 +15,12 @@ suite "Block maintenance":
     await testbed.stop()
 
   test "node retains file that hasn't expired yet":
-    let dataset = await testbed.dataset.upload(node)
+    let dataset = await testbed.dataset.data(size = 1024).upload(node)
     await sleepAsync(2.seconds)
     discard await testbed.api(node).download(!dataset.cid, network = false)
 
   test "node deletes expired file":
-    let dataset = await testbed.dataset.upload(node)
+    let dataset = await testbed.dataset.data(size = 1024).upload(node)
     await sleepAsync(10.seconds)
     try:
       discard await testbed.api(node).download(!dataset.cid, network = false)

--- a/tests/testbed/builders/dataset.nim
+++ b/tests/testbed/builders/dataset.nim
@@ -23,6 +23,9 @@ func data*(builder: DatasetBuilder, data: seq[byte]): DatasetBuilder =
 func data*(builder: DatasetBuilder, data: string): DatasetBuilder =
   builder.data(cast[seq[byte]](data))
 
+proc data*(builder: DatasetBuilder, size: int): DatasetBuilder =
+  builder.data(newSeqWith(size, rand(byte)))
+
 func mimetype*(builder: DatasetBuilder, mimetype: string): DatasetBuilder =
   builder.mimetype = some mimetype
   builder


### PR DESCRIPTION
Test could fail because the 4MB dataset was not entirely cleaned up in 10 seconds,
which triggered a network download (see bug #29) that made the test fail.