### PR TITLE
ci(deploy-devnet): adjust the workflow

### DIFF
--- a/.github/workflows/deploy-devnet.yml
+++ b/.github/workflows/deploy-devnet.yml
@@ -292,6 +292,9 @@ jobs:
           # .archivist.contracts
           jq -r '.archivist[].contracts |= "${{ needs.compute-variables.outputs.contracts_revision }}"' "${config}" > "${config_updated}" && rename_config
 
+          # .team.nodes.category.versions.version
+          jq -r '.team.nodes[].versions[].version |= "${{ needs.compute-variables.outputs.app_version }}"' "${config}" > "${config_updated}" && rename_config
+
       - name: Commit updated config
         uses: planetscale/ghcommit-action@v0.2.18
         with:


### PR DESCRIPTION
PR is a https://github.com/durability-labs/archivist-node/pull/32 followup and we performed the following adjustments
- Config should be updated at the end of the deployment
- Discord notifications are more readable and informative node
- Config commit message now contains repository name and event which triggered the update
- Now we update version for all the nodes categories in config