### PR TITLE
chore(docker): switch to a config endpoint

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -203,7 +203,7 @@ if [[ "$@" == *"prover"* ]]; then
 fi
 
 # Show
-echo -e "\nnode run parameters:"
+echo -e "\nNode run parameters:"
 vars=$(env | grep "ARCHIVIST_" | grep -v -e "[0-9]_SERVICE_" -e "[0-9]_NODEPORT_")
 echo -e "${vars//ARCHIVIST_/   - ARCHIVIST_}"
 echo -e "   - $@\n"


### PR DESCRIPTION
PR adjusts Docker entrypoint to use a config endpoint for SPR records and Marketplace address.

It means that now, we have to use 
```shell
# SPR
BOOTSTRAP_NODE_FROM_CONFIG_URL=https://config.archivist.storage/testnet.json
# or just
NETWORK=testnet

# Marketplace
MARKETPLACE_ADDRESS_FROM_CONFIG_URL=https://config.archivist.storage/testnet.json
```

A "Deprecation notice" was added for cases when `BOOTSTRAP_NODE_FROM_URL` or `MARKETPLACE_ADDRESS_FROM_URL` are passed and we will remove them later.