### PR TITLE
chore(docker): merge from_url and from_config_url helper variables

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -11,9 +11,8 @@ fi
 
 # Network
 CONFIG_URL="${CONFIG_URL:-https://config.archivist.storage}"
-BOOTSTRAP_NODE_FROM_URL="${BOOTSTRAP_NODE_FROM_URL}"
 if [[ -n "${NETWORK}" ]]; then
-  BOOTSTRAP_NODE_FROM_CONFIG_URL="${BOOTSTRAP_NODE_FROM_CONFIG_URL:-${CONFIG_URL}/${NETWORK}.json}"
+  BOOTSTRAP_NODE_FROM_URL="${BOOTSTRAP_NODE_FROM_URL:-${CONFIG_URL}/${NETWORK}/spr}"
 fi
 
 # Bootstrap node URL
@@ -37,35 +36,11 @@ if [[ -n "${BOOTSTRAP_NODE_URL}" ]]; then
   done
 fi
 
-# Bootstrap node from config URL
-if [[ -n "${BOOTSTRAP_NODE_FROM_CONFIG_URL}" ]]; then
-  WAIT=${BOOTSTRAP_NODE_FROM_CONFIG_URL_WAIT:-300}
-  SECONDS=0
-  SLEEP=1
-  # Run and retry if fail
-  while (( SECONDS < WAIT )); do
-    SPR=($(curl -s -f -m 5 "${BOOTSTRAP_NODE_FROM_CONFIG_URL}" | jq -r '.sprs[].records[]'))
-    # Check if exit code is 0 and returned value is not empty
-    if [[ $? -eq 0 && -n "${SPR}" ]]; then
-      for node in "${SPR[@]}"; do
-        bootstrap+="--bootstrap-node=$node "
-      done
-      set -- "$@" ${bootstrap}
-      break
-    else
-      # Sleep and check again
-      echo "Can't get SPR from ${BOOTSTRAP_NODE_FROM_CONFIG_URL} - Retry in $SLEEP seconds / $((WAIT - SECONDS))"
-      sleep $SLEEP
-    fi
-  done
-fi
-
 # Bootstrap node from URL
 if [[ -n "${BOOTSTRAP_NODE_FROM_URL}" ]]; then
   WAIT=${BOOTSTRAP_NODE_FROM_URL_WAIT:-300}
   SECONDS=0
   SLEEP=1
-  echo -e "\nDeprecation notice: BOOTSTRAP_NODE_FROM_URL variable is deprecated, please switch to a BOOTSTRAP_NODE_FROM_CONFIG_URL\n"
   # Run and retry if fail
   while (( SECONDS < WAIT )); do
     SPR=($(curl -s -f -m 5 "${BOOTSTRAP_NODE_FROM_URL}"))
@@ -84,32 +59,12 @@ if [[ -n "${BOOTSTRAP_NODE_FROM_URL}" ]]; then
   done
 fi
 
-# Marketplace address from config URL
-if [[ -n "${MARKETPLACE_ADDRESS_FROM_CONFIG_URL}" ]]; then
-  WAIT=${MARKETPLACE_ADDRESS_FROM_CONFIG_URL_WAIT:-300}
-  SECONDS=0
-  SLEEP=1
-  # Run and retry if fail
-  while (( SECONDS < WAIT )); do
-    MARKETPLACE_ADDRESS=($(curl -s -f -m 5 "${MARKETPLACE_ADDRESS_FROM_CONFIG_URL}" | jq -r '.marketplace[].contractAddress'))
-    # Check if exit code is 0 and returned value is not empty
-    if [[ $? -eq 0 && -n "${MARKETPLACE_ADDRESS}" ]]; then
-      export ARCHIVIST_MARKETPLACE_ADDRESS="${MARKETPLACE_ADDRESS}"
-      break
-    else
-      # Sleep and check again
-      echo "Can't get Marketplace address from ${MARKETPLACE_ADDRESS_FROM_CONFIG_URL} - Retry in $SLEEP seconds / $((WAIT - SECONDS))"
-      sleep $SLEEP
-    fi
-  done
-fi
-
 # Marketplace address from URL
 if [[ -n "${MARKETPLACE_ADDRESS_FROM_URL}" ]]; then
   WAIT=${MARKETPLACE_ADDRESS_FROM_URL_WAIT:-300}
   SECONDS=0
   SLEEP=1
-  echo -e "\nDeprecation notice: MARKETPLACE_ADDRESS_FROM_URL variable is deprecated, please switch to a MARKETPLACE_ADDRESS_FROM_CONFIG_URL\n"
+
   # Run and retry if fail
   while (( SECONDS < WAIT )); do
     MARKETPLACE_ADDRESS=($(curl -s -f -m 5 "${MARKETPLACE_ADDRESS_FROM_URL}"))
@@ -127,7 +82,12 @@ fi
 
 # Stop node run if unable to get SPR
 if [[ -n "${BOOTSTRAP_NODE_URL}" && -z "${ARCHIVIST_BOOTSTRAP_NODE}" ]]; then
-  echo "Unable to get SPR from ${BOOTSTRAP_NODE_URL} in ${BOOTSTRAP_NODE_URL_WAIT} seconds - Stop node run"
+  echo "Unable to get SPR from ${BOOTSTRAP_NODE_URL} - Stop node run"
+  exit 1
+fi
+
+if [[ -n "${BOOTSTRAP_NODE_FROM_URL}" && "$@" != *"--bootstrap-node=spr"* ]]; then
+  echo "Unable to get SPR from ${BOOTSTRAP_NODE_FROM_URL} - Stop node run"
   exit 1
 fi
 


### PR DESCRIPTION
PR partially roll-back https://github.com/durability-labs/archivist-node/pull/40 and merge helper variables, which are used to get values from external endpoints
```yaml
BOOTSTRAP_NODE_FROM_URL      = BOOTSTRAP_NODE_FROM_URL      + BOOTSTRAP_NODE_FROM_CONFIG_URL
MARKETPLACE_ADDRESS_FROM_URL = MARKETPLACE_ADDRESS_FROM_URL + MARKETPLACE_ADDRESS_FROM_CONFIG_URL
```

Variables with the suffix `FROM_CONFIG_URL` were added to distinguish them from the existing `FROM_URL` ones, because they are use JSON files located on config endpoint and require parsing tools and we used `jq` for that, which is fine in a Docker container where it is preinstalled.

But, we recently implemented a similar switch https://github.com/durability-labs/get-archivist/pull/4, and to not add one more dependency, on a binary run, like `jq`, it was decided to continue to use a text endpoint instead of a JSON one. Text endpoints for archivist-config repository were added in https://github.com/durability-labs/archivist-config/pull/8.

Another important motivation is that JSON structure might be changed over the time, because it was just recently introduced, and that will lead to the parsing query changes. With the text endpoints, we can change parsing filter in a single location - config endpoint repository publishing workflow - and for all the clients that will be transparent.

And a quick summary
- we have a single "source of true" which is a [archivist-config](https://github.com/durability-labs/archivist-config) repository and all changes needs to be done just there
- we are continue to use text endpoints for spr and marketplace
- text endpoints are updated from a JSON files in the same repository
