### PR TITLE
ci(deploy-on-network): set ssh port as a part of the host

### DIFF
--- a/.github/workflows/deploy-on-network.yml
+++ b/.github/workflows/deploy-on-network.yml
@@ -172,7 +172,6 @@ jobs:
           host: ${{ env.SSH_HOST }}
           username: ${{ secrets[format('{0}_SSH_USERNAME', inputs.network)] }}
           key: ${{ secrets[format('{0}_SSH_KEY', inputs.network)] }}
-          port: ${{ secrets[format('{0}_SSH_PORT', inputs.network)] }}
           script: ${{ env.ARCHIVIST_IMAGE }}
 
   cluster-nodes:
@@ -424,7 +423,6 @@ jobs:
           host: ${{ env.SSH_HOST }}
           username: ${{ secrets[format('{0}_SSH_USERNAME', inputs.network)] }}
           key: ${{ secrets[format('{0}_SSH_KEY', inputs.network)] }}
-          port: ${{ secrets[format('{0}_SSH_PORT', inputs.network)] }}
           script: ${{ env.ARCHIVIST_IMAGE }}
 
   notify:


### PR DESCRIPTION
PR adjusts update via SSH and now we set hosts port in the same secret
```diff
+ DEVNET_SSH_HOST_BOOTSTRAP_1 = 1.1.1.1:XX

- DEVNET_SSH_PORT = XX
- DEVNET_SSH_HOST_BOOTSTRAP_1 = 1.1.1.1
```

That is done to exclude the situations, when outputs can't be passed to another jobs because a part of them clashes with the port number which is a secret.