### PR TITLE
fix(ci): output which unittest is currently running

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -14,6 +14,9 @@ on:
       node_version:
         type: string
 
+env:
+  UNITTEST2_OUTPUT_LVL: VERBOSE # outputs which test is currently running
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Without this option, unittest2 outputs a dot (.) for every test, but that doesn't show in the github logs because it's not a full line of text until after the tests completed.