### PR TITLE
fix(sales): fix race condition in slot queue

### DIFF
--- a/archivist/sales.nim
+++ b/archivist/sales.nim
@@ -140,8 +140,7 @@ proc cleanUp(
   # draining the queue. Seen items will be ordered last.
   if reprocessSlot and request =? data.request and var item =? agent.data.slotQueueItem:
     let queue = sales.context.slotQueue
-    item.seen = true
-    trace "pushing ignored item to queue, marked as seen"
+    trace "pushing ignored item to queue"
     if err =? queue.push(item).errorOption:
       error "failed to readd slot to queue", errorType = $(type err), error = err.msg
 
@@ -254,15 +253,9 @@ proc load*(sales: Sales) {.async.} =
 proc OnAvailabilitySaved(
     sales: Sales, availability: Availability
 ) {.async: (raises: []).} =
-  ## When availabilities are modified or added, the queue should be unpaused if
-  ## it was paused and any slots in the queue should have their `seen` flag
-  ## cleared.
-  let queue = sales.context.slotQueue
-
-  queue.clearSeenFlags()
-  if queue.paused:
-    trace "unpausing queue after new availability added"
-    queue.unpause()
+  ## When availabilities are modified or added, the slot queue should be
+  ## notified so that it can reprocess slots.
+  sales.context.slotQueue.availabilitiesChanged()
 
 proc onStorageRequested(
     sales: Sales, requestId: RequestId, ask: StorageAsk, expiry: uint64

--- a/archivist/sales/slotqueue.nim
+++ b/archivist/sales/slotqueue.nim
@@ -31,7 +31,7 @@ type
     pricePerBytePerSecond: UInt256
     collateral: UInt256 # Collateral computed
     expiry: ?uint64
-    seen: bool
+    availabilitiesVersion: uint64 # used to check whether availabilities have changed
 
   # don't need to -1 to prevent overflow when adding 1 (to always allow push)
   # because AsyncHeapQueue size is of type `int`, which is larger than `uint16`
@@ -44,6 +44,7 @@ type
     running: bool
     workers: seq[Future[void].Raising([])]
     unpaused: AsyncEvent
+    availabilitiesVersion: uint64 # increases every time the availabilities change
 
   SlotQueueError = object of ArchivistError
   SlotQueueItemExistsError* = object of SlotQueueError
@@ -80,8 +81,8 @@ proc `<`*(a, b: SlotQueueItem): bool =
     if condition:
       score += 1'u8 shl addition
 
-  scoreA.addIf(a.seen < b.seen, 4)
-  scoreB.addIf(a.seen > b.seen, 4)
+  scoreA.addIf(a.availabilitiesVersion < b.availabilitiesVersion, 4)
+  scoreB.addIf(a.availabilitiesVersion > b.availabilitiesVersion, 4)
 
   scoreA.addIf(a.profitability > b.profitability, 3)
   scoreB.addIf(a.profitability < b.profitability, 3)
@@ -115,6 +116,7 @@ proc new*(
     queue: newAsyncHeapQueue[SlotQueueItem](maxSize.int + 1),
     running: false,
     unpaused: newAsyncEvent(),
+    availabilitiesVersion: 1,
   )
   # avoid instantiating `workers` in constructor to avoid side effects in
   # `newAsyncQueue` procedure
@@ -126,7 +128,7 @@ proc init*(
     ask: StorageAsk,
     expiry: ?uint64,
     collateral: UInt256,
-    seen = false,
+    availabilitiesVersion = 0'u64,
 ): SlotQueueItem =
   SlotQueueItem(
     requestId: requestId,
@@ -136,7 +138,7 @@ proc init*(
     pricePerBytePerSecond: ask.pricePerBytePerSecond,
     collateral: collateral,
     expiry: expiry,
-    seen: seen,
+    availabilitiesVersion: availabilitiesVersion,
   )
 
 proc init*(
@@ -146,9 +148,11 @@ proc init*(
     ask: StorageAsk,
     expiry: uint64,
     collateral: UInt256,
-    seen = false,
+    availabilitiesVersion = 0'u64,
 ): SlotQueueItem =
-  SlotQueueItem.init(requestId, slotIndex, ask, some expiry, collateral, seen)
+  SlotQueueItem.init(
+    requestId, slotIndex, ask, some expiry, collateral, availabilitiesVersion
+  )
 
 proc init*(
     _: type SlotQueueItem,
@@ -213,12 +217,6 @@ proc pricePerBytePerSecond*(self: SlotQueueItem): UInt256 =
 proc collateralPerByte*(self: SlotQueueItem): UInt256 =
   self.collateralPerByte
 
-proc seen*(self: SlotQueueItem): bool =
-  self.seen
-
-proc `seen=`*(self: var SlotQueueItem, seen: bool) =
-  self.seen = seen
-
 proc running*(self: SlotQueue): bool =
   self.running
 
@@ -252,7 +250,7 @@ proc push*(self: SlotQueue, item: SlotQueueItem): ?!void {.raises: [].} =
   logScope:
     requestId = item.requestId
     slotIndex = item.slotIndex
-    seen = item.seen
+    availabilitiesVersion = item.availabilitiesVersion
 
   trace "pushing item to queue"
 
@@ -275,7 +273,7 @@ proc push*(self: SlotQueue, item: SlotQueueItem): ?!void {.raises: [].} =
 
   # when slots are pushed to the queue, the queue should be unpaused if it was
   # paused
-  if self.paused and not item.seen:
+  if self.paused and item.availabilitiesVersion < self.availabilitiesVersion:
     trace "unpausing queue after new slot pushed"
     self.unpause()
 
@@ -320,22 +318,11 @@ proc delete*(self: SlotQueue, requestId: RequestId) =
 proc `[]`*(self: SlotQueue, i: Natural): SlotQueueItem =
   self.queue[i]
 
-proc clearSeenFlags*(self: SlotQueue) =
-  # Enumerate all items in the queue, overwriting each item with `seen = false`.
-  # To avoid issues with new queue items being pushed to the queue while all
-  # items are being iterated (eg if a new storage request comes in and pushes
-  # new slots to the queue), this routine must remain synchronous.
-
-  if self.queue.empty:
-    return
-
-  for item in self.queue.mitems:
-    item.seen = false # does not maintain the heap invariant
-
-  # force heap reshuffling to maintain the heap invariant
-  doAssert self.queue.update(self.queue[0]), "slot queue failed to reshuffle"
-
-  trace "all 'seen' flags cleared"
+proc availabilitiesChanged*(self: SlotQueue) =
+  inc self.availabilitiesVersion
+  if self.paused:
+    trace "unpausing queue after availabilities changed"
+    self.unpause()
 
 proc runWorker(self: SlotQueue) {.async: (raises: []).} =
   trace "slot queue worker loop started"
@@ -347,20 +334,18 @@ proc runWorker(self: SlotQueue) {.async: (raises: []).} =
       # block until unpaused is true/fired, ie wait for queue to be unpaused
       await self.unpaused.wait()
 
-      let item = await self.queue.pop() # if queue empty, wait here for new items
+      var item = await self.queue.pop() # if queue empty, wait here for new items
 
       logScope:
         reqId = item.requestId
         slotIdx = item.slotIndex
-        seen = item.seen
+        availabilitiesVersion = item.availabilitiesVersion
 
       if not self.running: # may have changed after waiting for pop
         trace "not running, exiting"
         break
 
-      # If, upon processing a slot, the slot item already has a `seen` flag set,
-      # the queue should be paused.
-      if item.seen:
+      if item.availabilitiesVersion == self.availabilitiesVersion:
         trace "processing already seen item, pausing queue",
           reqId = item.requestId, slotIdx = item.slotIndex
         self.pause()
@@ -375,6 +360,7 @@ proc runWorker(self: SlotQueue) {.async: (raises: []).} =
       without onProcessSlot =? self.onProcessSlot:
         raiseAssert "slot queue onProcessSlot not set"
 
+      item.availabilitiesVersion = self.availabilitiesVersion
       await onProcessSlot(item)
     except CancelledError:
       trace "slot queue worker cancelled"

--- a/archivist/sales/states/ignored.nim
+++ b/archivist/sales/states/ignored.nim
@@ -13,7 +13,7 @@ logScope:
 # not be reserved.
 
 type SaleIgnored* = ref object of SaleState
-  reprocessSlot*: bool # readd slot to queue with `seen` flag
+  reprocessSlot*: bool # readd slot to queue
   returnsCollateral*: bool # returns collateral when a reservation was created
 
 method `$`*(state: SaleIgnored): string =

--- a/tests/archivist/helpers/mockslotqueueitem.nim
+++ b/tests/archivist/helpers/mockslotqueueitem.nim
@@ -9,7 +9,7 @@ type MockSlotQueueItem* = object
   pricePerBytePerSecond*: UInt256
   collateral*: UInt256
   expiry*: uint64
-  seen*: bool
+  availabilitiesVersion*: uint64
 
 proc toSlotQueueItem*(item: MockSlotQueueItem): SlotQueueItem =
   SlotQueueItem.init(
@@ -21,6 +21,6 @@ proc toSlotQueueItem*(item: MockSlotQueueItem): SlotQueueItem =
       pricePerBytePerSecond: item.pricePerBytePerSecond,
     ),
     expiry = item.expiry,
-    seen = item.seen,
+    availabilitiesVersion = item.availabilitiesVersion,
     collateral = item.collateral,
   )

--- a/tests/archivist/sales/testsales.nim
+++ b/tests/archivist/sales/testsales.nim
@@ -330,15 +330,14 @@ asyncchecksuite "Sales":
 
     check eventually itemsProcessed.contains(expected)
 
-  test "items in queue are readded (and marked seen) once ignored":
+  test "items in queue are readded once ignored":
     await market.requestStorage(request)
     let items = SlotQueueItem.init(request, collateral = request.ask.collateralPerSlot)
     check eventually queue.len > 0
       # queue starts paused, allow items to be added to the queue
     check eventually queue.paused
-    # The first processed item will be will have been re-pushed with `seen =
-    # true`. Then, once this item is processed by the queue, its 'seen' flag
-    # will be checked, at which point the queue will be paused. This test could
+    # The first processed item will be will have been re-pushed. Then, once this
+    # item is processed by the queue, the queue will be paused. This test could
     # check item existence in the queue, but that would require inspecting
     # onProcessSlot to see which item was first, and overridding onProcessSlot
     # will prevent the queue working as expected in the Sales module.
@@ -346,9 +345,6 @@ asyncchecksuite "Sales":
 
     for item in items:
       check queue.contains(item)
-
-    for i in 0 ..< queue.len:
-      check queue[i].seen
 
   test "queue is paused once availability is insufficient to service slots in queue":
     createAvailability() # enough to fill a single slot
@@ -358,15 +354,12 @@ asyncchecksuite "Sales":
       # queue starts paused, allow items to be added to the queue
     check eventually queue.paused
     # The first processed item/slot will be filled (eventually). Subsequent
-    # items will be processed and eventually re-pushed with `seen = true`. Once
-    # a "seen" item is processed by the queue, the queue is paused. In the
-    # meantime, the other items that are process, marked as seen, and re-added
-    # to the queue may be processed simultaneously as the queue pausing.
-    # Therefore, there should eventually be 3 items remaining in the queue, all
-    # seen.
+    # items will be processed and eventually re-pushed. Once this item is
+    # processed by the queue, the queue is paused. In the meantime, the other
+    # items that are process, and re-added to the queue may be processed
+    # simultaneously as the queue pausing. Therefore, there should eventually be
+    # 3 items remaining in the queue
     check eventually queue.len == 3
-    for i in 0 ..< queue.len:
-      check queue[i].seen
 
   test "availability size is reduced by request slot size when fully downloaded":
     sales.onStore = proc(

--- a/tests/archivist/sales/testslotqueue.nim
+++ b/tests/archivist/sales/testslotqueue.nim
@@ -74,7 +74,7 @@ suite "Slot queue workers":
 
 suite "Slot queue":
   var onProcessSlotCalled = false
-  var onProcessSlotCalledWith: seq[(RequestId, uint16)]
+  var onProcessSlotCalledWith: seq[SlotQueueItem]
   var queue: SlotQueue
   var paused: bool
 
@@ -89,7 +89,7 @@ suite "Slot queue":
         checkpoint(exc.msg)
       finally:
         onProcessSlotCalled = true
-        onProcessSlotCalledWith.add (item.requestId, item.slotIndex)
+        onProcessSlotCalledWith.add(item)
 
     queue.start()
 
@@ -133,7 +133,7 @@ suite "Slot queue":
     check itemB < itemA # B higher priority than A
     check itemA > itemB
 
-  test "correct prioritizes SlotQueueItems based on 'seen'":
+  test "prioritizes items based on the availabilities version that it's seen":
     let request = StorageRequest.example
     let itemA = MockSlotQueueItem(
       requestId: request.id,
@@ -143,7 +143,7 @@ suite "Slot queue":
       pricePerBytePerSecond: 2.u256, # profitability is higher (good)
       collateral: 1.u256,
       expiry: 1.uint64,
-      seen: true, # seen (bad), more weight than profitability
+      availabilitiesVersion: 2, # (bad), more weight than profitability
     )
     let itemB = MockSlotQueueItem(
       requestId: request.id,
@@ -153,7 +153,7 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256, # profitability is lower (bad)
       collateral: 1.u256,
       expiry: 1.uint64,
-      seen: false, # not seen (good)
+      availabilitiesVersion: 1, # (good)
     )
     check itemB.toSlotQueueItem < itemA.toSlotQueueItem # B higher priority than A
     check itemA.toSlotQueueItem > itemB.toSlotQueueItem
@@ -168,7 +168,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256, # reward is lower (bad)
       collateral: 1.u256, # collateral is lower (good)
       expiry: 1.uint64,
-      seen: false,
     )
     let itemB = MockSlotQueueItem(
       requestId: request.id,
@@ -179,7 +178,6 @@ suite "Slot queue":
         # reward is higher (good), more weight than collateral
       collateral: 2.u256, # collateral is higher (bad)
       expiry: 1.uint64,
-      seen: false,
     )
 
     check itemB.toSlotQueueItem < itemA.toSlotQueueItem # < indicates higher priority
@@ -194,7 +192,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 2.u256, # collateral is higher (bad)
       expiry: 2.uint64, # expiry is longer (good)
-      seen: false,
     )
     let itemB = MockSlotQueueItem(
       requestId: request.id,
@@ -204,7 +201,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 1.u256, # collateral is lower (good), more weight than expiry
       expiry: 1.uint64, # expiry is shorter (bad)
-      seen: false,
     )
 
     check itemB.toSlotQueueItem < itemA.toSlotQueueItem # < indicates higher priority
@@ -219,7 +215,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 1.u256,
       expiry: 1.uint64, # expiry is shorter (bad)
-      seen: false,
     )
     let itemB = MockSlotQueueItem(
       requestId: request.id,
@@ -229,7 +224,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 1.u256,
       expiry: 2.uint64, # expiry is longer (good), more weight than slotSize
-      seen: false,
     )
 
     check itemB.toSlotQueueItem < itemA.toSlotQueueItem # < indicates higher priority
@@ -244,7 +238,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 1.u256,
       expiry: 1.uint64, # expiry is shorter (bad)
-      seen: false,
     )
     let itemB = MockSlotQueueItem(
       requestId: request.id,
@@ -254,7 +247,6 @@ suite "Slot queue":
       pricePerBytePerSecond: 1.u256,
       collateral: 1.u256,
       expiry: 1.uint64,
-      seen: false,
     )
 
     check itemA.toSlotQueueItem < itemB.toSlotQueueItem # < indicates higher priority
@@ -280,8 +272,7 @@ suite "Slot queue":
     let item2 = SlotQueueItem.example
     check queue.push(item1).isOk
     check queue.push(item2).isOk
-    check eventually onProcessSlotCalledWith ==
-      @[(item1.requestId, item1.slotIndex), (item2.requestId, item2.slotIndex)]
+    check eventually onProcessSlotCalledWith == @[item1, item2]
 
   test "can push items past number of maxWorkers":
     newSlotQueue(maxSize = 2, maxWorkers = 2)
@@ -364,7 +355,7 @@ suite "Slot queue":
     let last = items1[items1.high]
     check eventually queue.contains(last)
     queue.delete(last.requestId, last.slotIndex)
-    check not onProcessSlotCalledWith.anyIt(it == (last.requestId, last.slotIndex))
+    check not onProcessSlotCalledWith.anyIt(it == last)
 
   test "can delete all items by request id":
     newSlotQueue(maxSize = 8, maxWorkers = 1, processSlotDelay = 10.millis)
@@ -378,7 +369,7 @@ suite "Slot queue":
     check queue.push(items0).isOk
     check queue.push(items1).isOk
     queue.delete(request1.id)
-    check not onProcessSlotCalledWith.anyIt(it[0] == request1.id)
+    check not onProcessSlotCalledWith.anyIt(it.requestid == request1.id)
 
   test "can check if contains item":
     newSlotQueue(maxSize = 6, maxWorkers = 1, processSlotDelay = 10.millis)
@@ -457,7 +448,7 @@ suite "Slot queue":
     newSlotQueue(maxSize = 2, maxWorkers = 2)
     let item = SlotQueueItem.example
     check queue.push(item).isOk
-    check eventually onProcessSlotCalledWith == @[(item.requestId, item.slotIndex)]
+    check eventually onProcessSlotCalledWith == @[item]
 
   test "processes items in order of addition when only one item is added at a time":
     newSlotQueue(maxSize = 2, maxWorkers = 2)
@@ -484,15 +475,7 @@ suite "Slot queue":
     await sleepAsync(1.millis)
     check queue.push(item3).isOk
 
-    check eventually (
-      onProcessSlotCalledWith ==
-      @[
-        (item0.requestId, item0.slotIndex),
-        (item1.requestId, item1.slotIndex),
-        (item2.requestId, item2.slotIndex),
-        (item3.requestId, item3.slotIndex),
-      ]
-    )
+    check eventually onProcessSlotCalledWith == @[item0, item1, item2, item3]
 
   test "should process items in correct order according to the queue invariant when more than one item is added at a time":
     newSlotQueue(maxSize = 4, maxWorkers = 2)
@@ -518,15 +501,7 @@ suite "Slot queue":
 
     await sleepAsync(1.millis)
 
-    check eventually (
-      onProcessSlotCalledWith ==
-      @[
-        (item3.requestId, item3.slotIndex),
-        (item2.requestId, item2.slotIndex),
-        (item1.requestId, item1.slotIndex),
-        (item0.requestId, item0.slotIndex),
-      ]
-    )
+    check eventually onProcessSlotCalledWith == @[item3, item2, item1, item0]
 
   test "pushing items to queue unpauses queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
@@ -541,58 +516,63 @@ suite "Slot queue":
   test "pushing seen item does not unpause queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
-    let item0 = SlotQueueItem.init(
-      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
+    let item = SlotQueueItem.init(
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot
     )
-    check queue.paused
-    check queue.push(item0).isOk
+    check queue.push(item).isOk
+    check eventually onProcessSlotCalledWith.len == 1
+    let seenItem = onProcessSlotCalledWith[0]
+    queue.pause()
+    check queue.push(seenItem).isOk
     check queue.paused
 
   test "paused queue waits for unpause before continuing processing":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
     let item = SlotQueueItem.init(
-      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = false
+      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot
     )
     check queue.paused
     # push causes unpause
     check queue.push(item).isOk
     # check all items processed
-    check eventually onProcessSlotCalledWith == @[(item.requestId, item.slotIndex)]
+    check eventually onProcessSlotCalledWith == @[item]
     check eventually queue.len == 0
 
   test "processing a 'seen' item pauses the queue":
     newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
     let unseen = SlotQueueItem.init(
-      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = false
-    )
-    let seen = SlotQueueItem.init(
-      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot
     )
     # push causes unpause
     check queue.push(unseen).isSuccess
     # check all items processed
-    check eventually queue.len == 0
+    check eventually onProcessSlotCalledWith.len == 1
+    let seen = onProcessSlotCalledWith[0]
     # push seen item
     check queue.push(seen).isSuccess
     # queue should be paused
     check eventually queue.paused
 
-  test "item 'seen' flags can be cleared":
-    newSlotQueue(maxSize = 4, maxWorkers = 1)
+  test "a change in availabilities unpauses queue":
+    newSlotQueue(maxSize = 4, maxWorkers = 4)
     let request = StorageRequest.example
-    let item0 = SlotQueueItem.init(
-      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
+    let item = SlotQueueItem.init(
+      request.id, 0'u16, request.ask, 0, request.ask.collateralPerSlot
     )
-    let item1 = SlotQueueItem.init(
-      request.id, 1'u16, request.ask, 0, request.ask.collateralPerSlot, seen = true
-    )
-    check queue.push(item0).isOk
-    check queue.push(item1).isOk
-    check queue[0].seen
-    check queue[1].seen
-
-    queue.clearSeenFlags()
-    check queue[0].seen == false
-    check queue[1].seen == false
+    # push causes unpause
+    check queue.push(item).isSuccess
+    # check all items processed
+    check eventually onProcessSlotCalledWith.len == 1
+    let seen = onProcessSlotCalledWith[0]
+    # push seen item
+    check queue.push(seen).isSuccess
+    # queue should be paused
+    check eventually queue.paused
+    # notify queue of change in availabilities
+    queue.availabilitiesChanged()
+    # queue should be unpaused
+    check not queue.paused
+    # seen item is processed again
+    check eventually onProcessSlotCalledWith == @[item, seen]


### PR DESCRIPTION
When availabilities change, the `seen` flag of slot queue items was reset to 'false', but there could
still be items that are being processed by workers that do not get reset.

This change removes the boolean 'seen' flag, and
keeps track of changes in availabilities instead.