### PR TITLE
chore: add release issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,28 @@
+---
+name: Release
+about: Archivist release
+title: "Release Archivist 0.0.1"
+labels: release
+assignees: ''
+
+---
+
+### [Archivist release - v0.0.1](../releases/tag/v0.0.1)
+
+- [ ] Update contracts submodule if required
+- [ ] Deploy new smart contracts if required
+- [ ] Save contracts deployment artifacts if required
+- [ ] Update marketplace address if required
+- [ ] Prepare a release branch
+- [ ] Create a release
+- [ ] Post release
+  - [ ] Bootstrap nodes
+  - [ ] Storage nodes
+  - [ ] Validator nodes
+  - [ ] Projects nodes
+  - [ ] Discordbot
+  - [ ] Network crawler
+  - [ ] Helm chart
+  - [ ] Dappnode
+- [ ] Update documentation
+- [ ] Announcement


### PR DESCRIPTION
PR adds issue template for Archivist release.

In that way, we can start a new issue for a release is a few clicks

<img width="869" height="319" alt="Screenshot 2025-11-12 at 18 20 26" src="https://github.com/user-attachments/assets/55513bec-d379-4543-be2b-2ee9f5113954" />
