### PR TITLE
ci: fix condition for auto deployment on devnet

### DIFF
--- a/.github/workflows/docker-dist-tests.yml
+++ b/.github/workflows/docker-dist-tests.yml
@@ -73,7 +73,7 @@ jobs:
     name: Deploy Devnet
     uses: ./.github/workflows/deploy-on-network.yml
     needs: [build-and-push, deploy-testnet]
-    if: ${{ inputs.deploy_devnet || github.event_name == 'push' && github.ref_name == github.event.repository.default_branch }}
+    if: ${{ !(failure() || cancelled()) && (inputs.deploy_devnet || github.event_name == 'push' && github.ref_name == github.event.repository.default_branch) }}
     with:
       network: devnet
       archivist_image: ${{ needs.build-and-push.outputs.archivist_image }}


### PR DESCRIPTION
PR is a quick https://github.com/durability-labs/archivist-node/pull/49 followup and fixes conditional run for `deploy-devnet` job, which depends on `deploy-testnet`, which runs only on tags.