### PR TITLE
ci: show runner cpu info for docker builds

### DIFF
--- a/.github/workflows/docker-reusable.yml
+++ b/.github/workflows/docker-reusable.yml
@@ -126,6 +126,14 @@ jobs:
     env:
       PLATFORM: ${{ format('{0}/{1}', 'linux', matrix.target.arch) }}
     steps:
+      - name: Show runner info
+        run: |
+          for run in "lscpu" "lshw -class processor" "dmidecode -t processor";
+            do echo "${run}";
+            eval sudo ${run};
+            echo -e "\n\n\n";
+          done
+
       - name: Checkout
         uses: actions/checkout@v4
 


### PR DESCRIPTION
PR add a `Show runner info` step to the Docker builds and it runs several commands to get sho GitHub Actions runner CPU information.

We use more that one utility, because their output might differ slightly
<img width="1477" height="158" alt="Screenshot 2025-11-14 at 14 09 40" src="https://github.com/user-attachments/assets/6aa360a9-f7b9-4d54-b995-97f5ac2419f0" />
