### PR TITLE
ci: skip jobs run on releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ env:
 jobs:
   variables:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message || github.event.pull_request.title, '[release]') }}
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       nim_version: ${{ env.nim_version }}
@@ -58,7 +59,7 @@ jobs:
 
   linting:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.head_commit.message || github.event.pull_request.title, '[release]') }}
     steps:
       - uses: actions/checkout@v4
       - name: Check `nph` formatting


### PR DESCRIPTION
PR is a https://github.com/durability-labs/archivist-contracts/pull/22 followup and intended to minimize GitHub Actions runner usage by skipping jobs in the CI workflow then commit message or PR title contains `[release]`.

We just want to run a release as quickly as possible and to not wait for CI with its 30 jobs to finish, which might take several hours.