### PR TITLE
Option to skip circuit-download for docker images

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -136,7 +136,7 @@ fi
 
 # Circuit downloader
 # cirdl [circuitPath] [rpcEndpoint] [marketplaceAddress]
-if [[ -n "${DOWNLOAD_CIRCUIT}" ]]; then
+if [[ "$@" == *"prover"* && -z "${SKIP_DOWNLOAD_CIRCUIT}" ]]; then
   echo "Run Circuit downloader"
 
   # Set variables required by cirdl from command line arguments when passed


### PR DESCRIPTION
At the moment, running the image with "prover" will always result in a call to cirdl to download the circuits.

This PR makes it a separate flag, so you can enable prover without enabling cirdl.
This is useful when circuit files are provided via volume map and don't need to be downloaded.
At the same time, the option exists and so can be used for convenience and testing.