### PR TITLE
ci(deploy-on-network): fix cluster-tools update for devnet

### DIFF
--- a/.github/workflows/deploy-on-network.yml
+++ b/.github/workflows/deploy-on-network.yml
@@ -124,8 +124,8 @@ jobs:
           if [[ "${{ env.NETWORK }}" != "devnet" ]]; then
             echo "cluster_tools_update=true" >> $GITHUB_OUTPUT
           else
-            if [[ "${contracts_deploy}" != "true" ]]; then
-              echo "cluster_tools_update=false" >> $GITHUB_OUTPUT
+            if [[ "${contracts_deploy}" == "true" ]]; then
+              echo "cluster_tools_update=true" >> $GITHUB_OUTPUT
             fi
           fi
 


### PR DESCRIPTION
PR fixes `cluster_tools_update` output and set it properly for Devnet.

[During last auto deployment](https://github.com/durability-labs/archivist-node/actions/runs/19499921472), it was observed that `Cluster tools` job was skipped
<img width="374" height="630" alt="Screenshot 2025-11-19 at 17 27 25" src="https://github.com/user-attachments/assets/d08de255-75c0-4b71-99f4-6c4c195624c5" />
