### PR TITLE
fix(ci): split tests and fail fast

### DIFF
--- a/.github/workflows/ci-reusable.yml
+++ b/.github/workflows/ci-reusable.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include: ${{ fromJson(inputs.matrix) }}
 

--- a/tests/integration/30_minutes/testmarketplace.nim
+++ b/tests/integration/30_minutes/testmarketplace.nim
@@ -26,36 +26,3 @@ suite "Marketplace":
     let started = await testbed.marketplace.recordRequestStarted()
     await testbed.availability.update(provider)
     await started.waitForRequestStarted(request.id)
-
-  test "provider withdraws its payout when a request ends":
-    let provider = await testbed.node.provider.start()
-    let node = await testbed.node.persistence.start()
-    let request = await testbed.request.start(node)
-    let transfers = await testbed.marketplace.recordTransfers()
-    await testbed.eth.time.advance(request.duration)
-    await transfers.waitForTransferTo(provider)
-
-  test "requester withdraws remaining funds when a request ends":
-    discard await testbed.node.provider.start()
-    let node = await testbed.node.persistence.start()
-    let request = await testbed.request.start(node)
-    let transfers = await testbed.marketplace.recordTransfers()
-    await testbed.eth.time.advance(request.duration)
-    await transfers.waitForTransferTo(node)
-
-  test "provider withdraws its payout when a request is cancelled":
-    let provider = await testbed.node.provider.start()
-    let node = await testbed.node.persistence.start()
-    let filled = await testbed.marketplace.recordSlotFilled()
-    let request = await testbed.request.submit(node)
-    await filled.waitForSlotFilled(request.id)
-    let transfers = await testbed.marketplace.recordTransfers()
-    await testbed.eth.time.advance(request.expiry)
-    await transfers.waitForTransferTo(provider)
-
-  test "requester withdraws remaining funds when a request is cancelled":
-    let node = await testbed.node.persistence.start()
-    let request = await testbed.request.submit(node)
-    let transfers = await testbed.marketplace.recordTransfers()
-    await testbed.eth.time.advance(request.expiry)
-    await transfers.waitForTransferTo(node)

--- a/tests/integration/30_minutes/testwithdrawals.nim
+++ b/tests/integration/30_minutes/testwithdrawals.nim
@@ -1,0 +1,45 @@
+import pkg/asynctest/chronos/unittest2
+import ../../testbed
+
+suite "Marketplace withdrawals":
+  var testbed: Testbed
+
+  setup:
+    testbed = await Testbed.start()
+    discard await testbed.hardhat.start()
+
+  teardown:
+    await testbed.stop()
+
+  test "provider withdraws its payout when a request ends":
+    let provider = await testbed.node.provider.start()
+    let node = await testbed.node.persistence.start()
+    let request = await testbed.request.start(node)
+    let transfers = await testbed.marketplace.recordTransfers()
+    await testbed.eth.time.advance(request.duration)
+    await transfers.waitForTransferTo(provider)
+
+  test "requester withdraws remaining funds when a request ends":
+    discard await testbed.node.provider.start()
+    let node = await testbed.node.persistence.start()
+    let request = await testbed.request.start(node)
+    let transfers = await testbed.marketplace.recordTransfers()
+    await testbed.eth.time.advance(request.duration)
+    await transfers.waitForTransferTo(node)
+
+  test "provider withdraws its payout when a request is cancelled":
+    let provider = await testbed.node.provider.start()
+    let node = await testbed.node.persistence.start()
+    let filled = await testbed.marketplace.recordSlotFilled()
+    let request = await testbed.request.submit(node)
+    await filled.waitForSlotFilled(request.id)
+    let transfers = await testbed.marketplace.recordTransfers()
+    await testbed.eth.time.advance(request.expiry)
+    await transfers.waitForTransferTo(provider)
+
+  test "requester withdraws remaining funds when a request is cancelled":
+    let node = await testbed.node.persistence.start()
+    let request = await testbed.request.submit(node)
+    let transfers = await testbed.marketplace.recordTransfers()
+    await testbed.eth.time.advance(request.expiry)
+    await transfers.waitForTransferTo(node)


### PR DESCRIPTION
* re-enables accidentally disabled fail-fast (which made us run out of runners really fast)
* splits marketplace tests to keep them running within 30 minutes