### PR TITLE
feat(validator): retry on failure

### DIFF
--- a/archivist/marketplace/abstractmarketplace.nim
+++ b/archivist/marketplace/abstractmarketplace.nim
@@ -283,17 +283,17 @@ method unsubscribe*(subscription: Subscription) {.base, async: (raises: []).} =
 
 method queryPastSlotFilledEvents*(
     marketplace: AbstractMarketplace, fromBlock: BlockTag
-): Future[seq[SlotFilled]] {.base, async.} =
+): Future[seq[SlotFilled]] {.base, async: (raises: [CancelledError, MarketplaceError]).} =
   raiseAssert("not implemented")
 
 method queryPastSlotFilledEvents*(
     marketplace: AbstractMarketplace, blocksAgo: int
-): Future[seq[SlotFilled]] {.base, async.} =
+): Future[seq[SlotFilled]] {.base, async: (raises: [CancelledError, MarketplaceError]).} =
   raiseAssert("not implemented")
 
 method queryPastSlotFilledEvents*(
     marketplace: AbstractMarketplace, fromTime: SecondsSince1970
-): Future[seq[SlotFilled]] {.base, async.} =
+): Future[seq[SlotFilled]] {.base, async: (raises: [CancelledError, MarketplaceError]).} =
   raiseAssert("not implemented")
 
 method queryPastStorageRequestedEvents*(

--- a/archivist/marketplace/contracts/onchainmarketplace.nim
+++ b/archivist/marketplace/contracts/onchainmarketplace.nim
@@ -480,14 +480,14 @@ method unsubscribe*(subscription: OnChainMarketSubscription) {.async: (raises: [
 
 method queryPastSlotFilledEvents*(
     marketplace: OnChainMarketplace, fromBlock: BlockTag
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   convertEthersError("Failed to get past SlotFilled events from block"):
     return
       await marketplace.contract.queryFilter(SlotFilled, fromBlock, BlockTag.latest)
 
 method queryPastSlotFilledEvents*(
     marketplace: OnChainMarketplace, blocksAgo: int
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   convertEthersError("Failed to get past SlotFilled events"):
     let fromBlock = await marketplace.contract.provider.pastBlockTag(blocksAgo)
 
@@ -495,7 +495,7 @@ method queryPastSlotFilledEvents*(
 
 method queryPastSlotFilledEvents*(
     marketplace: OnChainMarketplace, fromTime: SecondsSince1970
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   convertEthersError("Failed to get past SlotFilled events from time"):
     let fromBlock = await marketplace.contract.provider.blockNumberForEpoch(fromTime)
     return await marketplace.queryPastSlotFilledEvents(BlockTag.init(fromBlock))

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -30,9 +30,11 @@ proc new*(
     clock: Clock,
     marketplace: AbstractMarketplace,
     config: ValidationConfig,
-    errorBackoff = ExponentialBackoff()
+    errorBackoff = ExponentialBackoff(),
 ): Validation =
-  Validation(clock: clock, marketplace: marketplace, config: config, errorBackoff: errorBackoff)
+  Validation(
+    clock: clock, marketplace: marketplace, config: config, errorBackoff: errorBackoff
+  )
 
 proc slots*(validation: Validation): seq[SlotId] =
   validation.slots.toSeq
@@ -127,8 +129,7 @@ proc findEpoch(validation: Validation, secondsAgo: uint64): SecondsSince1970 =
   return validation.clock.now - secondsAgo.int64
 
 proc queryPastSlotFilledEvents(
-  validation: Validation,
-  fromTime: SecondsSince1970
+    validation: Validation, fromTime: SecondsSince1970
 ): Future[seq[SlotFilled]] {.async: (raises: [CancelledError]).} =
   while true:
     try:
@@ -138,8 +139,7 @@ proc queryPastSlotFilledEvents(
       await validation.errorBackoff.applyDelay()
 
 proc slotState(
-  validation: Validation,
-  slotId: SlotId
+    validation: Validation, slotId: SlotId
 ): Future[SlotState] {.async: (raises: [CancelledError]).} =
   while true:
     try:
@@ -148,11 +148,14 @@ proc slotState(
       trace "retrieving slot state failed, retrying", error = error.msg
       await validation.errorBackoff.applyDelay()
 
-proc restoreHistoricalState(validation: Validation) {.async: (raises: [CancelledError]).} =
+proc restoreHistoricalState(
+    validation: Validation
+) {.async: (raises: [CancelledError]).} =
   info "Restoring historical state..."
   let requestDurationLimit = validation.marketplace.requestDurationLimit
   let startTimeEpoch = validation.findEpoch(secondsAgo = requestDurationLimit.u64)
-  let slotFilledEvents = await validation.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
+  let slotFilledEvents =
+    await validation.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
   for event in slotFilledEvents:
     if not validation.maxSlotsConstraintRespected:
       break

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -101,23 +101,25 @@ proc removeSlotsThatHaveEnded(validation: Validation) {.async.} =
 
 proc markProofAsMissing(
     validation: Validation, slotId: SlotId, period: ProofPeriod
-) {.async.} =
+) {.async: (raises: [CancelledError]).} =
   logScope:
     currentPeriod = validation.getCurrentPeriod()
 
-  try:
-    if await validation.marketplace.canMarkProofAsMissing(slotId, period):
-      trace "Marking proof as missing", slotId, periodProofMissed = period
-      await validation.marketplace.markProofAsMissing(slotId, period)
-    else:
-      let inDowntime {.used.} = await validation.marketplace.inDowntime(slotId)
-      trace "Proof not missing", checkedPeriod = period, inDowntime
-  except CancelledError:
-    raise
-  except CatchableError as e:
-    error "Marking proof as missing failed", msg = e.msg
+  while true:
+    try:
+      if await validation.marketplace.canMarkProofAsMissing(slotId, period):
+        trace "Marking proof as missing", slotId, periodProofMissed = period
+        await validation.marketplace.markProofAsMissing(slotId, period)
+      else:
+        trace "Proof not missing", checkedPeriod = period
+      break
+    except CancelledError as error:
+      raise error
+    except MarketplaceError as error:
+      trace "Marking proof as missing failed, retrying", error = error.msg
+      await validation.errorBackoff.applyDelay()
 
-proc markProofsAsMissing(validation: Validation) {.async.} =
+proc markProofsAsMissing(validation: Validation) {.async: (raises: [CancelledError]).} =
   let slots = validation.slots
   for slotId in slots:
     let previousPeriod = validation.getCurrentPeriod() - 1'u8

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -79,11 +79,21 @@ proc subscribeSlotFilled(validation: Validation) {.async.} =
   let subscription = await validation.marketplace.subscribeSlotFilled(onSlotFilled)
   validation.subscriptions.add(subscription)
 
+proc slotState(
+    validation: Validation, slotId: SlotId
+): Future[SlotState] {.async: (raises: [CancelledError]).} =
+  while true:
+    try:
+      return await validation.marketplace.slotState(slotId)
+    except MarketplaceError as error:
+      trace "retrieving slot state failed, retrying", error = error.msg
+      await validation.errorBackoff.applyDelay()
+
 proc removeSlotsThatHaveEnded(validation: Validation) {.async.} =
   var ended: HashSet[SlotId]
   let slots = validation.slots
   for slotId in slots:
-    let state = await validation.marketplace.slotState(slotId)
+    let state = await validation.slotState(slotId)
     if state != SlotState.Filled:
       trace "Removing slot", slotId, slotState = state
       ended.incl(slotId)
@@ -137,16 +147,6 @@ proc queryPastSlotFilledEvents(
       return await validation.marketplace.queryPastSlotFilledEvents(fromTime)
     except MarketplaceError as error:
       trace "querying past slot filled events failed, retrying", error = error.msg
-      await validation.errorBackoff.applyDelay()
-
-proc slotState(
-    validation: Validation, slotId: SlotId
-): Future[SlotState] {.async: (raises: [CancelledError]).} =
-  while true:
-    try:
-      return await validation.marketplace.slotState(slotId)
-    except MarketplaceError as error:
-      trace "retrieving slot state failed, retrying", error = error.msg
       await validation.errorBackoff.applyDelay()
 
 proc restoreHistoricalState(

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -162,12 +162,13 @@ proc restoreHistoricalState(
     if not validation.maxSlotsConstraintRespected:
       break
     let slotId = slotId(event.requestId, event.slotIndex)
-    let slotState = await validation.slotState(slotId)
-    if slotState == SlotState.Filled and validation.shouldValidateSlot(slotId):
-      trace "Adding slot [historical]", slotId
-      validation.slots.incl(slotId)
-    else:
-      trace "Ignoring slot [historical]", slotId, slotState
+    if validation.shouldValidateSlot(slotId):
+      let slotState = await validation.slotState(slotId)
+      if slotState == SlotState.Filled:
+        trace "Adding slot [historical]", slotId
+        validation.slots.incl(slotId)
+      else:
+        trace "Ignoring slot [historical]", slotId, slotState
   info "Historical state restored", numberOfSlots = validation.slots.len
 
 proc start*(

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -1,5 +1,6 @@
 import std/sets
 import std/sequtils
+import std/algorithm
 import pkg/chronos
 import pkg/questionable/results
 import pkg/stew/endians2
@@ -157,7 +158,7 @@ proc restoreHistoricalState(
   let slotFilledEvents =
     await validation.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
   trace "Loading historical slots", amount = slotFilledEvents.len
-  for event in slotFilledEvents:
+  for event in slotFilledEvents.reversed:
     if not validation.maxSlotsConstraintRespected:
       break
     let slotId = slotId(event.requestId, event.slotIndex)

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -84,7 +84,9 @@ proc slotState(
 ): Future[SlotState] {.async: (raises: [CancelledError]).} =
   while true:
     try:
-      return await validation.marketplace.slotState(slotId)
+      let state = await validation.marketplace.slotState(slotId)
+      validation.errorBackoff.clear()
+      return state
     except MarketplaceError as error:
       trace "retrieving slot state failed, retrying", error = error.msg
       await validation.errorBackoff.applyDelay()
@@ -112,6 +114,7 @@ proc markProofAsMissing(
         await validation.marketplace.markProofAsMissing(slotId, period)
       else:
         trace "Proof not missing", checkedPeriod = period
+      validation.errorBackoff.clear()
       break
     except CancelledError as error:
       raise error
@@ -146,7 +149,9 @@ proc queryPastSlotFilledEvents(
 ): Future[seq[SlotFilled]] {.async: (raises: [CancelledError]).} =
   while true:
     try:
-      return await validation.marketplace.queryPastSlotFilledEvents(fromTime)
+      let events = await validation.marketplace.queryPastSlotFilledEvents(fromTime)
+      validation.errorBackoff.clear()
+      return events
     except MarketplaceError as error:
       trace "querying past slot filled events failed, retrying", error = error.msg
       await validation.errorBackoff.applyDelay()

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -109,16 +109,16 @@ proc markProofsAsMissing(validation: Validation) {.async.} =
 
 proc run(validation: Validation) {.async: (raises: []).} =
   info "Validation started"
-  try:
-    while true:
+  while true:
+    try:
       await validation.waitUntilNextPeriod()
       await validation.removeSlotsThatHaveEnded()
       await validation.markProofsAsMissing()
-  except CancelledError:
-    trace "Validation stopped"
-    discard # do not propagate as run is asyncSpawned
-  except CatchableError as e:
-    error "Validation failed", msg = e.msg
+    except CancelledError:
+      trace "Validation stopped"
+      break # do not propagate as run is asyncSpawned
+    except CatchableError as e:
+      error "Validation error", msg = e.msg
 
 proc findEpoch(validation: Validation, secondsAgo: uint64): SecondsSince1970 =
   return validation.clock.now - secondsAgo.int64

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -156,6 +156,7 @@ proc restoreHistoricalState(
   let startTimeEpoch = validation.findEpoch(secondsAgo = requestDurationLimit.u64)
   let slotFilledEvents =
     await validation.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
+  trace "Loading historical slots", amount = slotFilledEvents.len
   for event in slotFilledEvents:
     if not validation.maxSlotsConstraintRespected:
       break
@@ -164,6 +165,8 @@ proc restoreHistoricalState(
     if slotState == SlotState.Filled and validation.shouldValidateSlot(slotId):
       trace "Adding slot [historical]", slotId
       validation.slots.incl(slotId)
+    else:
+      trace "Ignoring slot [historical]", slotId, slotState
   info "Historical state restored", numberOfSlots = validation.slots.len
 
 proc start*(

--- a/archivist/marketplace/validation.nim
+++ b/archivist/marketplace/validation.nim
@@ -5,6 +5,7 @@ import pkg/questionable/results
 import pkg/stew/endians2
 import ../clock
 import ../logutils
+import ../utils/exponentialbackoff
 import ./abstractmarketplace
 import ./validation/validationconfig
 
@@ -19,6 +20,7 @@ type Validation* = ref object
   subscriptions: seq[Subscription]
   running: Future[void]
   config: ValidationConfig
+  errorBackoff: ExponentialBackoff
 
 logScope:
   topics = "archivist validator"
@@ -28,8 +30,9 @@ proc new*(
     clock: Clock,
     marketplace: AbstractMarketplace,
     config: ValidationConfig,
+    errorBackoff = ExponentialBackoff()
 ): Validation =
-  Validation(clock: clock, marketplace: marketplace, config: config)
+  Validation(clock: clock, marketplace: marketplace, config: config, errorBackoff: errorBackoff)
 
 proc slots*(validation: Validation): seq[SlotId] =
   validation.slots.toSeq
@@ -123,17 +126,38 @@ proc run(validation: Validation) {.async: (raises: []).} =
 proc findEpoch(validation: Validation, secondsAgo: uint64): SecondsSince1970 =
   return validation.clock.now - secondsAgo.int64
 
-proc restoreHistoricalState(validation: Validation) {.async.} =
+proc queryPastSlotFilledEvents(
+  validation: Validation,
+  fromTime: SecondsSince1970
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError]).} =
+  while true:
+    try:
+      return await validation.marketplace.queryPastSlotFilledEvents(fromTime)
+    except MarketplaceError as error:
+      trace "querying past slot filled events failed, retrying", error = error.msg
+      await validation.errorBackoff.applyDelay()
+
+proc slotState(
+  validation: Validation,
+  slotId: SlotId
+): Future[SlotState] {.async: (raises: [CancelledError]).} =
+  while true:
+    try:
+      return await validation.marketplace.slotState(slotId)
+    except MarketplaceError as error:
+      trace "retrieving slot state failed, retrying", error = error.msg
+      await validation.errorBackoff.applyDelay()
+
+proc restoreHistoricalState(validation: Validation) {.async: (raises: [CancelledError]).} =
   info "Restoring historical state..."
   let requestDurationLimit = validation.marketplace.requestDurationLimit
   let startTimeEpoch = validation.findEpoch(secondsAgo = requestDurationLimit.u64)
-  let slotFilledEvents =
-    await validation.marketplace.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
+  let slotFilledEvents = await validation.queryPastSlotFilledEvents(fromTime = startTimeEpoch)
   for event in slotFilledEvents:
     if not validation.maxSlotsConstraintRespected:
       break
     let slotId = slotId(event.requestId, event.slotIndex)
-    let slotState = await validation.marketplace.slotState(slotId)
+    let slotState = await validation.slotState(slotId)
     if slotState == SlotState.Filled and validation.shouldValidateSlot(slotId):
       trace "Adding slot [historical]", slotId
       validation.slots.incl(slotId)

--- a/archivist/utils/exponentialbackoff.nim
+++ b/archivist/utils/exponentialbackoff.nim
@@ -8,9 +8,7 @@ type ExponentialBackoff* = ref object of RootObj
   lastHit: Moment
   backoffDelay: Duration
 
-method applyDelay*(
-    eb: ExponentialBackoff
-) {.base, async: (raises: [CancelledError]).} =
+method applyDelay*(eb: ExponentialBackoff) {.base, async: (raises: [CancelledError]).} =
   if Moment.now() - eb.lastHit > BackoffTimeout:
     # The last hit was too long ago. Reset.
     eb.backoffDelay = 0.seconds

--- a/archivist/utils/exponentialbackoff.nim
+++ b/archivist/utils/exponentialbackoff.nim
@@ -10,7 +10,7 @@ type ExponentialBackoff* = ref object of RootObj
 
 method applyDelay*(
     eb: ExponentialBackoff
-): Future[void] {.base, async: (raises: [CancelledError]).} =
+) {.base, async: (raises: [CancelledError]).} =
   if Moment.now() - eb.lastHit > BackoffTimeout:
     # The last hit was too long ago. Reset.
     eb.backoffDelay = 0.seconds

--- a/archivist/utils/exponentialbackoff.nim
+++ b/archivist/utils/exponentialbackoff.nim
@@ -8,6 +8,9 @@ type ExponentialBackoff* = ref object of RootObj
   lastHit: Moment
   backoffDelay: Duration
 
+func clear*(backoff: ExponentialBackoff) =
+  backoff.backoffDelay = 0.seconds
+
 method applyDelay*(eb: ExponentialBackoff) {.base, async: (raises: [CancelledError]).} =
   if Moment.now() - eb.lastHit > BackoffTimeout:
     # The last hit was too long ago. Reset.

--- a/tests/archivist/helpers/mockexponentialbackoff.nim
+++ b/tests/archivist/helpers/mockexponentialbackoff.nim
@@ -10,5 +10,6 @@ func new*(_: type MockExponentialBackoff): MockExponentialBackoff =
 
 method applyDelay*(
     eb: MockExponentialBackoff
-): Future[void] {.async: (raises: [CancelledError]).} =
+) {.async: (raises: [CancelledError]).} =
   inc eb.callCount
+  await sleepAsync(1.millis)

--- a/tests/archivist/helpers/mockexponentialbackoff.nim
+++ b/tests/archivist/helpers/mockexponentialbackoff.nim
@@ -8,8 +8,6 @@ type MockExponentialBackoff* = ref object of ExponentialBackoff
 func new*(_: type MockExponentialBackoff): MockExponentialBackoff =
   MockExponentialBackoff(callCount: 0)
 
-method applyDelay*(
-    eb: MockExponentialBackoff
-) {.async: (raises: [CancelledError]).} =
+method applyDelay*(eb: MockExponentialBackoff) {.async: (raises: [CancelledError]).} =
   inc eb.callCount
   await sleepAsync(1.millis)

--- a/tests/archivist/helpers/mockmarketplace.nim
+++ b/tests/archivist/helpers/mockmarketplace.nim
@@ -533,21 +533,21 @@ method queryPastStorageRequestedEvents*(
 
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, fromBlock: BlockTag
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   return marketplace.filled.map(
     slot => SlotFilled(requestId: slot.requestId, slotIndex: slot.slotIndex)
   )
 
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, blocksAgo: int
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   return marketplace.filled.map(
     slot => SlotFilled(requestId: slot.requestId, slotIndex: slot.slotIndex)
   )
 
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, fromTime: SecondsSince1970
-): Future[seq[SlotFilled]] {.async.} =
+): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
   let filtered = marketplace.filled.filter(
     proc(slot: MockSlot): bool =
       return slot.timestamp >= fromTime

--- a/tests/archivist/helpers/mockmarketplace.nim
+++ b/tests/archivist/helpers/mockmarketplace.nim
@@ -52,6 +52,8 @@ type
     errorOnFillSlot*: ?(ref MarketplaceError)
     errorOnFreeSlot*: ?(ref MarketplaceError)
     errorOnGetHost*: ?(ref MarketplaceError)
+    errorOnSlotState*: ?(ref MarketplaceError)
+    errorOnQueryPastSlotFilledEvents*: ?(ref MarketplaceError)
     clock: Clock
 
   Fulfillment* = object
@@ -200,6 +202,9 @@ method requestState*(
 method slotState*(
     marketplace: MockMarketplace, slotId: SlotId
 ): Future[SlotState] {.async: (raises: [CancelledError, MarketplaceError]).} =
+  if error =? marketplace.errorOnSlotState:
+    raise error
+
   if slotId notin marketplace.slotState:
     return SlotState.Free
 
@@ -534,6 +539,9 @@ method queryPastStorageRequestedEvents*(
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, fromBlock: BlockTag
 ): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
+  if error =? marketplace.errorOnQueryPastSlotFilledEvents:
+    raise error
+
   return marketplace.filled.map(
     slot => SlotFilled(requestId: slot.requestId, slotIndex: slot.slotIndex)
   )
@@ -541,6 +549,9 @@ method queryPastSlotFilledEvents*(
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, blocksAgo: int
 ): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
+  if error =? marketplace.errorOnQueryPastSlotFilledEvents:
+    raise error
+
   return marketplace.filled.map(
     slot => SlotFilled(requestId: slot.requestId, slotIndex: slot.slotIndex)
   )
@@ -548,6 +559,9 @@ method queryPastSlotFilledEvents*(
 method queryPastSlotFilledEvents*(
     marketplace: MockMarketplace, fromTime: SecondsSince1970
 ): Future[seq[SlotFilled]] {.async: (raises: [CancelledError, MarketplaceError]).} =
+  if error =? marketplace.errorOnQueryPastSlotFilledEvents:
+    raise error
+
   let filtered = marketplace.filled.filter(
     proc(slot: MockSlot): bool =
       return slot.timestamp >= fromTime

--- a/tests/archivist/marketplace/testvalidation.nim
+++ b/tests/archivist/marketplace/testvalidation.nim
@@ -9,6 +9,7 @@ import archivist/clock
 import ../../asynctest
 import ../helpers/mockmarketplace
 import ../helpers/mockclock
+import ../helpers/mockexponentialbackoff
 import ../examples
 import ../helpers
 
@@ -28,6 +29,7 @@ asyncchecksuite "validation":
   var clock: MockClock
   var groupIndex: uint16
   var validation: Validation
+  var backoff: MockExponentialBackoff
 
   proc initValidationConfig(
       maxSlots: MaxSlots, validationGroups: ?ValidationGroups, groupIndex: uint16 = 0
@@ -45,12 +47,13 @@ asyncchecksuite "validation":
       groupIndex: uint16 = 0,
   ): Validation =
     let validationConfig = initValidationConfig(maxSlots, validationGroups, groupIndex)
-    Validation.new(clock, marketplace, validationConfig)
+    Validation.new(clock, marketplace, validationConfig, backoff)
 
   setup:
     groupIndex = groupIndexForSlotId(slot.id, !validationGroups)
     clock = MockClock.new()
     marketplace = MockMarketplace.new(clock)
+    backoff = MockExponentialBackoff.new()
     marketplace.config.proofs.period = period
     marketplace.config.proofs.timeout = timeout
     validation =
@@ -237,4 +240,17 @@ asyncchecksuite "validation":
     !await validation.start()
     check validation.slots == @[slot.id]
 
+  test "retries when querying slot filled events fails":
+    let error = newException(MarketplaceError, "some error")
+    marketplace.errorOnQueryPastSlotFilledEvents = some error
+    let starting = validation.start()
+    check eventually backoff.callCount > 0
+    await starting.cancelAndWait()
 
+  test "retries when retrieving slot state fails":
+    await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
+    let error = newException(MarketplaceError, "some error")
+    marketplace.errorOnSlotState = some error
+    let starting = validation.start()
+    check eventually backoff.callCount > 0
+    await starting.cancelAndWait()

--- a/tests/archivist/marketplace/testvalidation.nim
+++ b/tests/archivist/marketplace/testvalidation.nim
@@ -170,70 +170,71 @@ asyncchecksuite "validation":
       await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
     check validation.slots.len == maxSlots
 
-  suite "restoring historical state":
-    test "it retrieves the historical state " & "for max 30 days in the past":
-      let earlySlot = Slot.example
-      await marketplace.fillSlot(
-        earlySlot.request.id, earlySlot.slotIndex, proof, collateral
-      )
-      let fromTime = clock.now()
-      clock.set(fromTime + 1)
-      await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
+  test "it retrieves the historical state " & "for max 30 days in the past":
+    let earlySlot = Slot.example
+    await marketplace.fillSlot(
+      earlySlot.request.id, earlySlot.slotIndex, proof, collateral
+    )
+    let fromTime = clock.now()
+    clock.set(fromTime + 1)
+    await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
 
-      let duration: times.Duration = initDuration(days = 30)
-      clock.set(fromTime + duration.inSeconds + 1)
+    let duration: times.Duration = initDuration(days = 30)
+    clock.set(fromTime + duration.inSeconds + 1)
+
+    validation =
+      newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
+    !await validation.start()
+
+    check validation.slots == @[slot.id]
+
+  for state in [SlotState.Finished, SlotState.Failed]:
+    test "when restoring historical state, " & fmt"it excludes slots in {state} state":
+      let slot1 = Slot.example
+      let slot2 = Slot.example
+      await marketplace.fillSlot(slot1.request.id, slot1.slotIndex, proof, collateral)
+      await marketplace.fillSlot(slot2.request.id, slot2.slotIndex, proof, collateral)
+
+      marketplace.slotState[slot1.id] = state
 
       validation =
         newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
       !await validation.start()
 
-      check validation.slots == @[slot.id]
+      check validation.slots == @[slot2.id]
 
-    for state in [SlotState.Finished, SlotState.Failed]:
-      test "when restoring historical state, " & fmt"it excludes slots in {state} state":
-        let slot1 = Slot.example
-        let slot2 = Slot.example
-        await marketplace.fillSlot(slot1.request.id, slot1.slotIndex, proof, collateral)
-        await marketplace.fillSlot(slot2.request.id, slot2.slotIndex, proof, collateral)
-
-        marketplace.slotState[slot1.id] = state
-
-        validation =
-          newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
-        !await validation.start()
-
-        check validation.slots == @[slot2.id]
-
-    test "it does not monitor more than the maximum number of slots ":
-      for _ in 0 ..< maxSlots + 1:
-        let slot = Slot.example
-        await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
-      validation = newValidation(clock, marketplace, maxSlots, ValidationGroups.none)
-      !await validation.start()
-      check validation.slots.len == maxSlots
-
-    test "slot is not observed if it is not in the validation group":
+  test "it does not monitor more than the maximum number of slots ":
+    for _ in 0 ..< maxSlots + 1:
+      let slot = Slot.example
       await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
-      validation = newValidation(
-        clock,
-        marketplace,
-        maxSlots,
-        validationGroups,
-        (groupIndex + 1) mod uint16(!validationGroups),
-      )
-      !await validation.start()
-      check validation.slots.len == 0
+    validation = newValidation(clock, marketplace, maxSlots, ValidationGroups.none)
+    !await validation.start()
+    check validation.slots.len == maxSlots
 
-    test "slot should be observed if maxSlots is set to 0":
-      await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
-      validation =
-        newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
-      !await validation.start()
-      check validation.slots == @[slot.id]
+  test "slot is not observed if it is not in the validation group":
+    await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
+    validation = newValidation(
+      clock,
+      marketplace,
+      maxSlots,
+      validationGroups,
+      (groupIndex + 1) mod uint16(!validationGroups),
+    )
+    !await validation.start()
+    check validation.slots.len == 0
 
-    test "slot should be observed if validation " &
-      "group is not set (and maxSlots is not 0)":
-      await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
-      validation = newValidation(clock, marketplace, maxSlots, ValidationGroups.none)
-      !await validation.start()
-      check validation.slots == @[slot.id]
+  test "slot should be observed if maxSlots is set to 0":
+    await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
+    validation =
+      newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
+    !await validation.start()
+    check validation.slots == @[slot.id]
+
+  test "slot should be observed if validation " &
+    "group is not set (and maxSlots is not 0)":
+    await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
+    validation = newValidation(clock, marketplace, maxSlots, ValidationGroups.none)
+    !await validation.start()
+    check validation.slots == @[slot.id]
+
+

--- a/tests/archivist/marketplace/testvalidation.nim
+++ b/tests/archivist/marketplace/testvalidation.nim
@@ -185,8 +185,7 @@ asyncchecksuite "validation":
     let duration: times.Duration = initDuration(days = 30)
     clock.set(fromTime + duration.inSeconds + 1)
 
-    validation =
-      newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
+    validation = newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
     !await validation.start()
 
     check validation.slots == @[slot.id]
@@ -228,8 +227,7 @@ asyncchecksuite "validation":
 
   test "slot should be observed if maxSlots is set to 0":
     await marketplace.fillSlot(slot.request.id, slot.slotIndex, proof, collateral)
-    validation =
-      newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
+    validation = newValidation(clock, marketplace, maxSlots = 0, ValidationGroups.none)
     !await validation.start()
     check validation.slots == @[slot.id]
 


### PR DESCRIPTION
Validator no longer bails out when an error occurs:
- while validating; it will continue the next period
- while loading slots; it will retry (with exponential back-off)

Additional fixes on validator startup:
- load newest slots first
- no longer load slot state when slot is not in your validation group

depends on #119