### PR TITLE
feat(nat): `--nat:none` no longer tries to find external address

### DIFF
--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -100,9 +100,8 @@ proc start*(s: NodeServer) {.async.} =
   await s.natTraversal.start()
 
   let announceAddresses = s.archivistNode.switch.peerInfo.addrs
-  let discoveryPort = s.config.discoveryPort
-  let discoveryAddress = MultiAddress.init(IPv4_any(), udpProtocol, discoveryPort)
-  await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
+  let discoveryAddresses = discoveryAddresses(announceAddresses, s.config.discoveryPort)
+  await s.natTraversal.mapPorts(discoveryAddresses) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateDhtRecord(mapped)
   await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateAnnounceRecord(mapped)

--- a/archivist/nat.nim
+++ b/archivist/nat.nim
@@ -14,3 +14,7 @@ export traversal.new
 export traversal.start
 export traversal.stop
 export traversal.mapPorts
+
+import ./nat/discovery
+
+export discovery.discoveryAddresses

--- a/archivist/nat/discovery.nim
+++ b/archivist/nat/discovery.nim
@@ -1,0 +1,15 @@
+import std/net
+import pkg/questionable
+import pkg/libp2p/multiaddress
+import ./multiaddress
+
+func discoveryAddresses*(
+    announceAddresses: seq[MultiAddress], discoveryPort: Port
+): seq[MultiAddress] =
+  for announceAddress in announceAddresses:
+    if ip =? announceAddress.ip:
+      let protocol = IpTransportProtocol.udpProtocol
+      let port = discoveryPort
+      let discoveryAddress = MultiAddress.init(ip, protocol, port)
+      if discoveryAddress notin result:
+        result.add(discoveryAddress)

--- a/archivist/nat/portmapping.nim
+++ b/archivist/nat/portmapping.nim
@@ -34,19 +34,6 @@ proc mapExternalIp(mapping: PortMapping, address: MultiAddress): ?!MultiAddress 
     return failure "Missing port in multiaddress"
   success MultiAddress.init(!mapping.config.externalIp, protocol, port)
 
-proc mapRoutingTable(mapping: PortMapping, address: MultiAddress): ?!MultiAddress =
-  without ip =? address.ip and port =? address.port:
-    return failure "Missing IP address or port in multiaddress"
-  let bindAddress = initTAddress(ip, port)
-  if bindAddress.isGlobal and bindAddress.isUnicast:
-    return success address
-  let destination = initTAddress(static parseIpAddress("1.1.1.1"), Port(0))
-  let route = getBestRoute(destination)
-  if route.source.isGlobal and route.source.isUnicast:
-    if source =? route.source.address.catch and protocol =? address.protocol:
-      return success MultiAddress.init(source, protocol, port)
-  failure "No routable IP address found, check your network connection"
-
 proc mapPmp(mapping: var PortMapping, address: MultiAddress): ?!MultiAddress =
   without protocol =? address.protocol and internal =? address.port:
     return failure "Missing port in multiaddress"
@@ -82,11 +69,6 @@ proc mapUpnp(mapping: var PortMapping, address: MultiAddress): ?!MultiAddress =
   success MultiAddress.init(externalIp, protocol, mapped)
 
 proc mapAny(mapping: var PortMapping, address: MultiAddress): ?!MultiAddress =
-  let routingResult = mapping.mapRoutingTable(address)
-  if mapped =? routingResult:
-    mapping.config = NatConfig.noNat
-    return success mapped
-
   let upnpResult = mapping.mapUpnp(address)
   if mapped =? upnpResult:
     mapping.config = NatConfig.upnp
@@ -97,7 +79,6 @@ proc mapAny(mapping: var PortMapping, address: MultiAddress): ?!MultiAddress =
     mapping.config = NatConfig.pmp(mapping.config.gateway)
     return success mapped
 
-  debug "port mapping using routing table failed", error = routingResult.error.msg
   debug "port mapping using upnp failed", error = upnpResult.error.msg
   debug "port mapping using pmp failed", error = pmpResult.error.msg
 
@@ -114,7 +95,7 @@ proc map*(mapping: var PortMapping, address: MultiAddress): ?!MultiAddress =
   of NatStrategy.ExternalIp:
     mapping.mapExternalIp(address)
   of NatStrategy.None:
-    mapping.mapRoutingTable(address)
+    success address
 
 proc deleteUpnpMappings(mapping: var PortMapping): ?!void =
   for (address, external) in mapping.externalPorts.pairs:

--- a/tests/testbed/builders/node.nim
+++ b/tests/testbed/builders/node.nim
@@ -199,7 +199,7 @@ proc discoveryPortResolved(builder: NodeBuilder): Future[Port] {.async.} =
   builder.discoveryPort |? await findFreePort(address, Port(8090), Udp)
 
 proc natResolved(builder: NodeBuilder): string =
-  builder.nat |? "extip:127.0.0.1"
+  builder.nat |? "none"
 
 proc bootstrapNodesResolved(builder: NodeBuilder): Future[seq[string]] {.async.} =
   if nodes =? builder.bootstrapNodes:


### PR DESCRIPTION
- when specifying `--nat:none`, no more address translation happens
- we no longer try to find the external address of the host through the OS routing table
- discovery address is no longer hardcoded to `0.0.0.0`, but derived from the libp2p peer addresses
