### PR TITLE
Bugfix - DHT unaddressable nodes

### DIFF
--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -102,10 +102,11 @@ proc start*(s: NodeServer) {.async.} =
   let announceAddresses = s.archivistNode.switch.peerInfo.addrs
   let discoveryPort = s.config.discoveryPort
   let discoveryAddress = MultiAddress.init(IPv4_any(), udpProtocol, discoveryPort)
-  await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
-    s.archivistNode.discovery.updateDhtRecord(mapped)
   await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateAnnounceRecord(mapped)
+  await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
+    s.archivistNode.discovery.updateDhtRecord(mapped)
+
 
   await s.connectMarketplace()
   await s.archivistNode.start()

--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -102,8 +102,8 @@ proc start*(s: NodeServer) {.async.} =
   let announceAddresses = s.archivistNode.switch.peerInfo.addrs
   let discoveryPort = s.config.discoveryPort
   let discoveryAddress = MultiAddress.init(IPv4_any(), udpProtocol, discoveryPort)
-  # await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
-  #   s.archivistNode.discovery.updateAnnounceRecord(mapped)
+  await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
+    s.archivistNode.discovery.updateAnnounceRecord(mapped)
   await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateDhtRecord(mapped)
 

--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -102,8 +102,8 @@ proc start*(s: NodeServer) {.async.} =
   let announceAddresses = s.archivistNode.switch.peerInfo.addrs
   let discoveryPort = s.config.discoveryPort
   let discoveryAddress = MultiAddress.init(IPv4_any(), udpProtocol, discoveryPort)
-  await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
-    s.archivistNode.discovery.updateAnnounceRecord(mapped)
+  # await s.natTraversal.mapPorts(announceAddresses) do(mapped: seq[MultiAddress]):
+  #   s.archivistNode.discovery.updateAnnounceRecord(mapped)
   await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateDhtRecord(mapped)
 

--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -107,7 +107,6 @@ proc start*(s: NodeServer) {.async.} =
   await s.natTraversal.mapPorts(@[discoveryAddress]) do(mapped: seq[MultiAddress]):
     s.archivistNode.discovery.updateDhtRecord(mapped)
 
-
   await s.connectMarketplace()
   await s.archivistNode.start()
   s.restServer.start()


### PR DESCRIPTION
Since https://github.com/durability-labs/archivist-node/pull/110 we have had "unaddressable nodes" show up in DHT interactions. The problem can be traced down to the incorrect initialization order of the announce-address record, and the DHT discovery record. This PR fixes that issue in the simplest possible way.
