### PR TITLE
fix/segfault in blockexchange

### DIFF
--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -763,7 +763,7 @@ proc taskHandler*(
         itemsByIndex[item[0]] = (item[1], item[2])
 
       for index in indices:
-        if entry =? itemsByIndex.?[index]:
+        if entry =? itemsByIndex .? [index]:
           let (blk, proof) = entry
           blockDeliveries.add(
             BlockDelivery(

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -750,7 +750,7 @@ proc taskHandler*(
         blocksByCid[blk.cid] = blk
 
       for address in nonLeafAddresses:
-        if blk =? blocksByCid.getOrDefault(address.cid).option:
+        if blk =? blocksByCid.?[address.cid]:
           blockDeliveries.add(BlockDelivery(address: address, blk: blk))
 
     for treeCid, indices in leafIndicesByTree:

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -750,7 +750,7 @@ proc taskHandler*(
         blocksByCid[blk.cid] = blk
 
       for address in nonLeafAddresses:
-        if blk =? blocksByCid.?[address.cid]:
+        if blk =? blocksByCid .? [address.cid]:
           blockDeliveries.add(BlockDelivery(address: address, blk: blk))
 
     for treeCid, indices in leafIndicesByTree:

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -763,7 +763,7 @@ proc taskHandler*(
         itemsByIndex[item[0]] = (item[1], item[2])
 
       for index in indices:
-        if entry =? itemsByIndex.getOrDefault(index).option:
+        if entry =? itemsByIndex.?[index]:
           let (blk, proof) = entry
           blockDeliveries.add(
             BlockDelivery(


### PR DESCRIPTION
Crash is caused by `itemsByIndex.getOrDefault(index)`

Because 'itemsByIndex' is a table of key: natural, value: tuple, then the default value returned here is a non-nil tuple containing a nil-block and nil-proof. This is seen as a valid value by the option method. Execution continues and runs into the segfault.

By request of Mark, the same table .getOrDefault construction is replaced for blocksByCid as well.

The scenario that reproduces this crash is found in the release tests at SwarmTests.StreamOneToMany. Since the issue occurs only sometimes, the swarm test has been adjusted to catch this problem more reliably.

