### PR TITLE
API: Get dataset status

### DIFF
--- a/archivist/rest/api.nim
+++ b/archivist/rest/api.nim
@@ -64,7 +64,9 @@ proc formatManifestBlocks(node: ArchivistNodeRef): Future[JsonNode] {.async.} =
 
   return %RestContentList.init(content)
 
-proc formatDatasetStatus(node: ArchivistNodeRef, repostore: RepoStore, cid: Cid): Future[?!JsonNode] {.async.} =
+proc formatDatasetStatus(
+    node: ArchivistNodeRef, repostore: RepoStore, cid: Cid
+): Future[?!JsonNode] {.async.} =
   without manifest =? (await node.fetchManifest(cid)), err:
     error "Failed to fetch manifest", err = err.msg
     return failure(err)

--- a/archivist/rest/api.nim
+++ b/archivist/rest/api.nim
@@ -64,6 +64,17 @@ proc formatManifestBlocks(node: ArchivistNodeRef): Future[JsonNode] {.async.} =
 
   return %RestContentList.init(content)
 
+proc formatDatasetStatus(node: ArchivistNodeRef, repostore: RepoStore, cid: Cid): Future[?!JsonNode] {.async.} =
+  without manifest =? (await node.fetchManifest(cid)), err:
+    error "Failed to fetch manifest", err = err.msg
+    return failure(err)
+
+  without overlay =? (await repostore.getOverlay(manifest.treeCid)), err:
+    error "Failed to fetch overlay", err = err.msg
+    return failure(err)
+
+  return success(%RestDatasetStatus.init(cid, overlay))
+
 proc isPending(resp: HttpResponseRef): bool =
   ## Checks that an HttpResponseRef object is still pending; i.e.,
   ## that no body has yet been sent. This helps us guard against calling
@@ -260,6 +271,18 @@ proc initDataApi(node: ArchivistNodeRef, repoStore: RepoStore, router: var RestR
 
   router.api(MethodGet, "/api/archivist/v1/data") do() -> RestApiResponse:
     let json = await formatManifestBlocks(node)
+    return RestApiResponse.response($json, contentType = "application/json")
+
+  router.api(MethodGet, "/api/archivist/v1/data/{cid}/status") do(
+    cid: Cid, resp: HttpResponseRef
+  ) -> RestApiResponse:
+    if cid.isErr:
+      return RestApiResponse.error(Http400, $cid.error())
+
+    without json =? (await formatDatasetStatus(node, repostore, cid.get())), err:
+      error "Failed create RestDatasetStatus object", err = err.msg
+      return RestApiResponse.error(Http404, err.msg)
+
     return RestApiResponse.response($json, contentType = "application/json")
 
   router.api(MethodOptions, "/api/archivist/v1/data/{cid}") do(

--- a/archivist/rest/json.nim
+++ b/archivist/rest/json.nim
@@ -85,12 +85,11 @@ proc init*(_: type RestContentList, content: seq[RestContent]): RestContentList 
 proc init*(_: type RestContent, cid: Cid, manifest: Manifest): RestContent =
   RestContent(cid: cid, manifest: manifest)
 
-proc init*(_: type RestDatasetStatus, cid: Cid, overlay: OverlayMetadata): RestDatasetStatus =
+proc init*(
+    _: type RestDatasetStatus, cid: Cid, overlay: OverlayMetadata
+): RestDatasetStatus =
   RestDatasetStatus(
-    cid: cid,
-    status: overlay.status,
-    expiry: overlay.expiry,
-    blocks: $(overlay.blocks)
+    cid: cid, status: overlay.status, expiry: overlay.expiry, blocks: $(overlay.blocks)
   )
 
 proc init*(_: type RestNode, node: dn.Node): RestNode =

--- a/archivist/rest/json.nim
+++ b/archivist/rest/json.nim
@@ -1,11 +1,13 @@
 import pkg/questionable
 import pkg/stew/byteutils
+import pkg/stew/bitseqs
 import pkg/libp2p
 import pkg/archivistdht/discv5/node as dn
 import pkg/archivistdht/discv5/routing_table as rt
 import ../marketplace
 import ../utils/json
 import ../manifest
+import ../stores/repostore/types
 import ../units
 import ../clock
 
@@ -46,6 +48,12 @@ type
   RestContentList* = object
     content* {.serialize.}: seq[RestContent]
 
+  RestDatasetStatus* = object
+    cid* {.serialize.}: Cid
+    status* {.serialize.}: OverlayStatus
+    expiry* {.serialize.}: SecondsSince1970
+    blocks* {.serialize.}: string
+
   RestNode* = object
     nodeId* {.serialize.}: RestNodeId
     peerId* {.serialize.}: PeerId
@@ -76,6 +84,14 @@ proc init*(_: type RestContentList, content: seq[RestContent]): RestContentList 
 
 proc init*(_: type RestContent, cid: Cid, manifest: Manifest): RestContent =
   RestContent(cid: cid, manifest: manifest)
+
+proc init*(_: type RestDatasetStatus, cid: Cid, overlay: OverlayMetadata): RestDatasetStatus =
+  RestDatasetStatus(
+    cid: cid,
+    status: overlay.status,
+    expiry: overlay.expiry,
+    blocks: $(overlay.blocks)
+  )
 
 proc init*(_: type RestNode, node: dn.Node): RestNode =
   RestNode(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -396,6 +396,34 @@ components:
         manifest:
           $ref: "#/components/schemas/ManifestItem"
 
+    DatasetStatus:
+      type: object
+      required:
+        - cid
+        - status
+        - expiry
+        - blocks
+      properties:
+        cid:
+          $ref: "#/components/schemas/Cid"
+        status:
+          type: string
+          enum:
+            - Pending
+            - Failure
+            - Storing
+            - Downloading
+            - Repairing
+            - Completed
+            - Deleting
+        expiry:
+          $ref: "#/components/schemas/Expiry"
+        blocks:
+          type: string
+          nullable: false
+          description: "Bitmap representation of dataset blocks present locally. Starts with '0b'."
+          example: 0b000000000000111111111111000000000000
+
     ManifestItem:
       type: object
       required:
@@ -560,6 +588,25 @@ paths:
         "500":
           description: Well it was bad-bad and the upload did not work out
 
+  "/data/{cid}/status":
+    get:
+      summary: "Gets status for local dataset."
+      tags: [Data]
+      operationId: getDatasetStatus
+      responses:
+        "200":
+          description: Retrieved dataset status object
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DatasetStatus"
+        "400":
+          description: Invalid CID is specified
+        "404":
+          description: Dataset specified by the CID is not found
+        "500":
+          description: Well it was bad-bad
+   
   "/data/{cid}":
     get:
       summary: "Download a file from the local node in a streaming manner. If the file is not available locally, a 404 is returned."

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -593,6 +593,13 @@ paths:
       summary: "Gets status for local dataset."
       tags: [Data]
       operationId: getDatasetStatus
+      parameters:
+        - in: path
+          name: cid
+          required: true
+          schema:
+            $ref: "#/components/schemas/Cid"
+          description: Dataset for which to get status object
       responses:
         "200":
           description: Retrieved dataset status object

--- a/tests/integration/5_minutes/testdatasets.nim
+++ b/tests/integration/5_minutes/testdatasets.nim
@@ -69,3 +69,10 @@ suite "Node datasets":
       fail()
     except HttpError as error:
       check "413" in error.msg
+
+  test "node can return status of a dataset":
+    let dataset = await testbed.dataset.upload(node)
+    let status = await testbed.api(node).status(!dataset.cid)
+    check status["cid"].getStr() == !dataset.cid
+    check status["status"].getStr() == "Completed"
+    check status["blocks"].getStr() == "0b11111111"

--- a/tests/integration/5_minutes/testdatasets.nim
+++ b/tests/integration/5_minutes/testdatasets.nim
@@ -71,8 +71,9 @@ suite "Node datasets":
       check "413" in error.msg
 
   test "node can return status of a dataset":
-    let dataset = await testbed.dataset.upload(node)
+    let datasetSize = 7 * 512 * 1024 # 7 blocks of data
+    let dataset = await testbed.dataset.data(datasetSize).upload(node)
     let status = await testbed.api(node).status(!dataset.cid)
     check status["cid"].getStr() == !dataset.cid
     check status["status"].getStr() == "Completed"
-    check status["blocks"].getStr() == "0b11111111"
+    check status["blocks"].getStr() == "0b1111111"

--- a/tests/testbed.nim
+++ b/tests/testbed.nim
@@ -130,6 +130,7 @@ export api.downloadManifest
 export api.downloadInBackground
 export api.delete
 export api.setLogLevel
+export api.status
 
 import ./testbed/network/node
 

--- a/tests/testbed/builders/api.nim
+++ b/tests/testbed/builders/api.nim
@@ -146,3 +146,10 @@ proc delete*(builder: ApiBuilder, cid: string) {.async.} =
 
 proc setLogLevel*(builder: ApiBuilder, level: string) {.async.} =
   await Http.post(builder.url & "/debug/chronicles/loglevel?level=" & level).close()
+
+proc status*(builder: RawBuilder, cid: string): Future[HttpResponse] {.async.} =
+  var url = builder.url & "/data/" & cid & "/status"
+  await Http.get(url)
+
+proc status*(builder: ApiBuilder, cid: string): Future[JsonNode] {.async.} =
+  await builder.raw.status(cid).readJson()


### PR DESCRIPTION
A GET to `/data/{cid}/status`
will now return you a lovely:
```
{
	"cid": "zDvZRwzm7romTUsasBXoYuZyoezhb3iLJFCNZdViSj9SpnYTGoes",
	"status": "Completed",
	"expiry": 1781697303,
	"blocks": "0b1111111111111111111111111"
}
```
This will enable us to keep an eye on datasets in nodes. Useful for testing, but also for users/app developers in general.

Note:
The bitmap returned for blocks states that it is "optimistic": 0 = the block is definitely abscent. But 1 = the block is only probably present. We don't know how often this will not be true. If we discover this is becoming unreliable, we can consider adding/expanding this call to enable explicit block confirmation.
