### PR TITLE
fix(repostore): initialize quota usage and total blocks

### DIFF
--- a/archivist/stores/repostore/operations.nim
+++ b/archivist/stores/repostore/operations.nim
@@ -64,6 +64,35 @@ declareGauge(archivist_repostore_bytes_reserved, "archivist repostore bytes rese
 ## should never touch those.
 ##
 
+proc getQuotaUsage(
+    self: RepoStore
+): Future[?!QuotaUsage] {.async: (raises: [CancelledError]).} =
+  without record =? await self.metaDs.get(QuotaUsedKey, QuotaUsage), error:
+    if error of KVStoreKeyNotFound:
+      return success QuotaUsage.default
+    else:
+      return failure error
+  success record.val
+
+proc getTotalBlocks(
+    self: RepoStore
+): Future[?!Natural] {.async: (raises: [CancelledError]).} =
+  without record =? await self.metaDs.get(ArchivistTotalBlocksKey, Natural), error:
+    if error of KVStoreKeyNotFound:
+      return success 0.Natural
+    else:
+      return failure error
+  success record.val
+
+proc initializeCounters*(
+    self: RepoStore
+): Future[?!void] {.async: (raises: [CancelledError]).} =
+  let quotaUsage = ?await self.getQuotaUsage()
+  let totalBlocks = ?await self.getTotalBlocks()
+  self.quotaUsage = quotaUsage
+  self.totalBlocks = totalBlocks
+  success()
+
 proc updateCounters*(
     self: RepoStore, quotaDelta = 0, reservedDelta = 0, blocksDelta = 0
 ): Future[?!void] {.async: (raises: [CancelledError]).} =

--- a/archivist/stores/repostore/store.nim
+++ b/archivist/stores/repostore/store.nim
@@ -633,6 +633,14 @@ proc start*(
     return
 
   trace "Starting repo"
+
+  if error =? (await self.initializeCounters()).errorOption:
+    trace "Initializing counters failed", error = error.msg
+    let message = "unable to start repo store: " & error.msg
+    raise newException(ArchivistError, message)
+  trace "Counters initialized",
+    quotaUsage = self.quotaUsage, totalBlocks = self.totalBlocks
+
   self.started = true
 
 proc stop*(self: RepoStore): Future[void] {.async: (raises: []).} =

--- a/tests/integration/5_minutes/testdatasets.nim
+++ b/tests/integration/5_minutes/testdatasets.nim
@@ -33,6 +33,13 @@ suite "Node datasets":
     check totalBlocksAfter > totalBlocksBefore
     check quotaUsedAfter >= quotaUsedBefore + dataset.data.len
 
+  test "used and available space is preserved after a restart":
+    discard await testbed.dataset.upload(node)
+    let before = await testbed.api(node).getSpace()
+    await node.restart()
+    let after = await testbed.api(node).getSpace()
+    check before == after
+
   test "node returns list of local datasets":
     let dataset1 = await testbed.dataset.upload(node)
     let dataset2 = await testbed.dataset.upload(node)


### PR DESCRIPTION
Quota usage and total number of blocks were persisted, but never read.