### PR TITLE
batch per peer

### DIFF
--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -7,6 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+import std/hashes
 import std/options
 import std/sequtils
 import std/sets
@@ -392,24 +393,22 @@ proc failBlockRequest(
   self.pendingBlocks.failWantHandle(address, errType, msg)
 
 proc sendRequestBatch(
-    self: BlockExcEngine, addresses: seq[BlockAddress]
+    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
   if addresses.len == 0:
+    trace "Cannot send empty batch", peerId
     return
 
-  var byPeer: Table[PeerId, seq[BlockAddress]]
-  for address in addresses.deduplicate():
-    var shouldRetry = false
+  let peer = self.peers.get(peerId)
+  if peer.isNil:
+    trace "Unable to find peer to send batch to", peerId
+    for address in addresses:
+      self.scheduleBlockSend(address)
+    return
 
-    defer:
-      self.pendingBlocks.clearScheduled(address)
-      self.pendingBlocks.decRetries(address)
-
-      if shouldRetry:
-        self.scheduleBlockSend(address)
-
+  var batch: seq[BlockAddress]
+  for address in addresses:
     if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
-      trace "Address is not pending or already requested", address
       continue
 
     if self.pendingBlocks.retriesExhausted(address):
@@ -420,77 +419,141 @@ proc sendRequestBatch(
       )
       continue
 
-    let peers = self.peers.getPeersForBlock(address)
-    if peers.with.len == 0 and peers.without.len > 0:
-      await self.refreshBlockKnowledge()
-
-    if peers.with.len == 0:
-      self.searchForNewPeers(address.cidOrTreeCid)
-      trace "No peer for block, discovery started and retry scheduled", address
-      shouldRetry = true
-      continue
-
-    let peer = self.selectPeer(peers.with)
-    if peer.isNil:
-      trace "No peer context, skipping", peer = peer.id
-      shouldRetry = true
-      continue
-
     let requested =
-      self.pendingBlocks.markRequested(address, peer.id, self.blockRequestTimeout)
-    if requested != peer.id.some:
+      self.pendingBlocks.markRequested(address, peerId, self.blockRequestTimeout)
+
+    if requested != peerId.some:
       trace "Block already requested from another peer", address, peer = requested.get
       continue
 
+    self.pendingBlocks.decRetries(address)
     peer.blockRequestScheduled(address)
-    byPeer.mgetOrPut(peer.id, @[]).add(address)
+    self.pendingBlocks.clearScheduled(address)
+    batch.add(address)
 
-  for peerId, batch in byPeer:
-    if batch.len == 0:
-      continue
+  if batch.len == 0:
+    trace "Batch is empty, skipping", peerId
+    return
 
-    if err =? catchAsync(await self.sendWantBlock(batch, peerId)).errorOption:
-      warn "Failed to send wantBlock batch", peer = peerId, err = err.msg
-      let peer = self.peers.get(peerId)
-      if not peer.isNil:
-        for address in batch:
-          await self.pendingBlocks.clearRequest(address, peerId)
-          peer.blockRequestCancelled(address)
-          peer.cleanPresence(address)
-          self.scheduleBlockSend(address)
-      continue
+  if err =? catchAsync(await self.sendWantBlock(batch, peerId)).errorOption:
+    warn "Failed to send wantBlock batch", peer = peerId, err = err.msg
+    for address in batch:
+      await self.pendingBlocks.clearRequest(address, peerId)
+      peer.blockRequestCancelled(address)
+      peer.cleanPresence(address)
+      self.scheduleBlockSend(address)
+
+proc sendRequestBatchTask(
+    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
+) {.async: (raises: []).} =
+  try:
+    await self.sendRequestBatch(peerId, addresses)
+  except CatchableError as exc:
+    trace "Exception sending batch", peerId
+
+type
+  BatchTimer = Future[void]
+  BatchReq = object
+    batch: seq[BlockAddress]
+    timer: BatchTimer
+
+func hash(timer: BatchTimer): Hash =
+  cast[pointer](timer).hash
 
 proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
+  var
+    byPeer: Table[PeerId, BatchReq]
+    timers: Table[Future[void], PeerId]
+
   try:
     while self.blockexcRunning:
-      var batch = @[await self.requestQueue.get()]
-      let timer = sleepAsync(DefaultWantBlockBatchTimeout)
-
+      var finished: FutureBase
+      let next = self.requestQueue.get()
       try:
-        while batch.len < self.wantBlockBatchSize:
-          let next = self.requestQueue.get()
-          try:
-            await next or timer
-          finally:
-            if not next.finished:
-              await noCancel next.cancelAndWait()
-
-          if not next.completed:
-            break
-
-          let address = await next
-          trace "Got block from request queue", address
-          batch.add(address)
-
-          if timer.finished:
-            break
+        finished = await FutureBase(next).race(timers.keys.toSeq.mapIt(FutureBase(it)))
       finally:
-        if not timer.finished:
-          await noCancel timer.cancelAndWait()
+        if not next.finished:
+          await noCancel next.cancelAndWait()
 
-      await self.sendRequestBatch(batch)
+      if not next.completed:
+        let batchTimer = BatchTimer(finished)
+        if peerId =? timers .? [batchTimer]:
+          timers.del(batchTimer)
+          if batchReq =? byPeer .? [peerId]:
+            byPeer.del(peerId)
+            if batchReq.batch.len > 0:
+              self.trackedFutures.track(
+                self.sendRequestBatchTask(peerId, batchReq.batch)
+              )
+              trace "Request batch task dispatched after timeout deadline",
+                peerId, batch = batchReq.batch.len
+          else:
+            warn "No peer found for timer", peerId
+        continue
+
+      let address = await next
+      trace "Got block from request queue", address
+
+      var shouldRetry = false
+      defer:
+        if shouldRetry:
+          self.pendingBlocks.clearScheduled(address)
+          self.scheduleBlockSend(address)
+
+      if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
+        trace "Address is not pending or already requested", address
+        shouldRetry = true
+        continue
+
+      if self.pendingBlocks.retriesExhausted(address):
+        trace "Retries exhausted, skipping block", address
+        archivist_block_exchange_requests_failed_total.inc()
+        await self.failBlockRequest(
+          address, RetriesExhaustedEngineError, "Block request retries exhausted"
+        )
+        continue
+
+      let peers = self.peers.getPeersForBlock(address)
+      if peers.with.len == 0 and peers.without.len > 0:
+        await self.refreshBlockKnowledge()
+
+      if peers.with.len == 0:
+        self.searchForNewPeers(address.cidOrTreeCid)
+        trace "No peer for block, discovery started and retry scheduled", address
+        shouldRetry = true
+        continue
+
+      let peer = self.selectPeer(peers.with)
+      if peer.isNil:
+        trace "No peer context, skipping", address
+        shouldRetry = true
+        continue
+
+      var peerBatch: seq[BlockAddress]
+      byPeer.withValue(peer.id, req):
+        req[].batch.add(address)
+        peerBatch = req[].batch
+      do:
+        let timer = sleepAsync(DefaultWantBlockBatchTimeout)
+        byPeer[peer.id] = BatchReq(batch: @[address], timer: timer)
+        timers[timer] = peer.id
+        continue
+
+      if peerBatch.len >= self.wantBlockBatchSize:
+        if batchReq =? byPeer .? [peer.id]:
+          let batchTimer = BatchTimer(batchReq.timer)
+          await noCancel batchTimer.cancelAndWait()
+          timers.del(batchTimer)
+          byPeer.del(peer.id)
+          self.trackedFutures.track(self.sendRequestBatchTask(peer.id, peerBatch))
   except CancelledError:
+    byPeer.clear()
+    timers.clear()
     warn "Request scheduling cancelled!"
+
+  for timer in timers.keys.toSeq:
+    if not timer.finished:
+      await noCancel timer.cancelAndWait()
 
   trace "Block request scheduling stopped"
 

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -108,6 +108,7 @@ type
     blockexcRunning: bool
     maxBlocksPerMessage: int
     wantBlockBatchSize: int
+    wantBlockBatchTimeout: Duration
     blockRequestTimeout: Duration
     pendingBlocks*: PendingBlocksManager
     discovery*: DiscoveryEngine
@@ -535,7 +536,7 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
         req[].batch.add(address)
         peerBatch = req[].batch
       do:
-        let timer = sleepAsync(DefaultWantBlockBatchTimeout)
+        let timer = sleepAsync(self.wantBlockBatchTimeout)
         byPeer[peer.id] = BatchReq(batch: @[address], timer: timer)
         timers[timer] = peer.id
         continue
@@ -1021,6 +1022,8 @@ proc new*(
     maxBlocksPerMessage = DefaultMaxBlocksPerMessage,
     concurrentTasks = DefaultConcurrentTasks,
     selectPeer: PeerSelector = randomPeer,
+    wantBlockBatchSize = DefaultWantBlockBatchSize,
+    wantBlockBatchTimeout = DefaultWantBlockBatchTimeout,
     blockRequestTimeout = DefaultRequestTimeout,
 ): BlockExcEngine =
   let self = BlockExcEngine(
@@ -1031,7 +1034,8 @@ proc new*(
     concurrentTasks: concurrentTasks,
     trackedFutures: TrackedFutures(),
     maxBlocksPerMessage: maxBlocksPerMessage,
-    wantBlockBatchSize: DefaultWantBlockBatchSize,
+    wantBlockBatchSize: wantBlockBatchSize,
+    wantBlockBatchTimeout: wantBlockBatchTimeout,
     blockRequestTimeout: blockRequestTimeout,
     taskQueue: newAsyncHeapQueue[BlockExcPeerCtx](DefaultTaskQueueSize),
     requestQueue: newAsyncQueue[BlockAddress](DefaultRequestQueueSize),

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -279,6 +279,7 @@ proc scheduleBlockSend(
   address: BlockAddress,
   immediate = false,
   delay = DefaultBlockSendRetryDelay,
+  forceDelay = false,
 ) {.gcsafe, raises: [].}
 
 proc failBlockRequest(
@@ -322,6 +323,7 @@ proc scheduleBlockSendTask(
     address: BlockAddress,
     immediate: bool,
     delay = DefaultBlockSendRetryDelay,
+    forceDelay = false,
 ) {.async: (raises: []).} =
   without handle =? self.pendingBlocks.getPendingHandle(address):
     self.pendingBlocks.clearScheduled(address)
@@ -340,7 +342,7 @@ proc scheduleBlockSendTask(
   if not self.pendingBlocks.markScheduled(address):
     return
 
-  if not immediate and not self.pendingBlocks.isFirstAttempt(address):
+  if forceDelay or (not immediate and not self.pendingBlocks.isFirstAttempt(address)):
     let timer = sleepAsync(delay)
     try:
       await handle or timer
@@ -371,8 +373,11 @@ proc scheduleBlockSend(
     address: BlockAddress,
     immediate = false,
     delay = DefaultBlockSendRetryDelay,
+    forceDelay = false,
 ) {.gcsafe, raises: [].} =
-  self.trackedFutures.track(self.scheduleBlockSendTask(address, immediate, delay))
+  self.trackedFutures.track(
+    self.scheduleBlockSendTask(address, immediate, delay, forceDelay)
+  )
 
 proc clearBlockRequestState(
     self: BlockExcEngine, address: BlockAddress
@@ -494,15 +499,9 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
       let address = await next
       trace "Got block from request queue", address
 
-      var shouldRetry = false
-      defer:
-        if shouldRetry:
-          self.pendingBlocks.clearScheduled(address)
-          self.scheduleBlockSend(address)
-
       if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
         trace "Address is not pending or already requested", address
-        shouldRetry = true
+        self.pendingBlocks.clearScheduled(address)
         continue
 
       if self.pendingBlocks.retriesExhausted(address):
@@ -519,14 +518,16 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
 
       if peers.with.len == 0:
         self.searchForNewPeers(address.cidOrTreeCid)
+        self.pendingBlocks.clearScheduled(address)
+        self.scheduleBlockSend(address, forceDelay = true)
         trace "No peer for block, discovery started and retry scheduled", address
-        shouldRetry = true
         continue
 
       let peer = self.selectPeer(peers.with)
       if peer.isNil:
         trace "No peer context, skipping", address
-        shouldRetry = true
+        self.pendingBlocks.clearScheduled(address)
+        self.scheduleBlockSend(address, forceDelay = true)
         continue
 
       var peerBatch: seq[BlockAddress]

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -23,6 +23,17 @@ import pkg/archivist/utils/asyncheapqueue
 import ../../../asynctest
 import ../../helpers
 
+const NopSendWantListProc = proc(
+    id: PeerId,
+    addresses: seq[BlockAddress],
+    priority: int32 = 0,
+    cancel: bool = false,
+    wantType: WantType = WantType.WantHave,
+    full: bool = false,
+    sendDontHave: bool = false,
+) {.async: (raises: [CancelledError]).} =
+  discard
+
 const NopSendWantCancellationsProc = proc(
     id: PeerId, addresses: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
@@ -426,7 +437,12 @@ asyncchecksuite "Block Download":
       SQLiteKVStore.new(SqliteMemory, tp).tryGet(),
       SQLiteKVStore.new(SqliteMemory, tp).tryGet(),
     )
-    network = BlockExcNetwork()
+    network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: NopSendWantListProc,
+        sendWantCancellations: NopSendWantCancellationsProc,
+      )
+    )
 
     discovery = DiscoveryEngine.new(
       localStore,
@@ -598,6 +614,130 @@ asyncchecksuite "Block Download":
 
     check wantBlockBatches == @[@[firstAddress], @[secondAddress]]
 
+  test "Should batch by peer before splitting want block requests":
+    let
+      peer2Key = PrivateKey.random(rng[]).tryGet()
+      peer2Id = PeerId.init(peer2Key.getPublicKey().tryGet()).tryGet()
+      peer2Ctx = BlockExcPeerCtx(id: peer2Id)
+      requestCount = DefaultWantBlockBatchSize * 4
+      addresses =
+        toSeq(0 ..< requestCount).mapIt(BlockAddress.init(blocks[0].cid, Natural(it)))
+      done = newAsyncEvent()
+
+    var
+      sentAddresses = initHashSet[BlockAddress]()
+      expectedPeer1 = initHashSet[BlockAddress]()
+      expectedPeer2 = initHashSet[BlockAddress]()
+      wantBlockBatches: seq[tuple[peer: PeerId, addresses: seq[BlockAddress]]]
+
+    proc sendWantList(
+        id: PeerId,
+        requestedAddresses: seq[BlockAddress],
+        priority: int32 = 0,
+        cancel: bool = false,
+        wantType: WantType = WantType.WantHave,
+        full: bool = false,
+        sendDontHave: bool = false,
+    ) {.async: (raises: [CancelledError]).} =
+      if wantType == WantBlock:
+        wantBlockBatches.add((peer: id, addresses: requestedAddresses))
+        for address in requestedAddresses:
+          sentAddresses.incl(address)
+        if sentAddresses.len == requestCount and not done.isSet:
+          done.fire()
+
+    engine.peers.add(peer2Ctx)
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
+      )
+    )
+
+    for i, address in addresses:
+      if i mod 2 == 0:
+        expectedPeer1.incl(address)
+        peerCtx.setPresence(Presence(address: address, have: true))
+      else:
+        expectedPeer2.incl(address)
+        peer2Ctx.setPresence(Presence(address: address, have: true))
+
+    let pendingHandles = engine.requestDeliveries(addresses).tryGet()
+    check pendingHandles.len == requestCount
+    await done.wait().wait(1.seconds)
+
+    let
+      peer1Batches = wantBlockBatches.filterIt(it.peer == peerId)
+      peer2Batches = wantBlockBatches.filterIt(it.peer == peer2Id)
+
+    var
+      peer1Sent = initHashSet[BlockAddress]()
+      peer2Sent = initHashSet[BlockAddress]()
+
+    for batch in peer1Batches:
+      for address in batch.addresses:
+        peer1Sent.incl(address)
+
+    for batch in peer2Batches:
+      for address in batch.addresses:
+        peer2Sent.incl(address)
+
+    check:
+      pendingHandles.len == requestCount
+      sentAddresses == addresses.toHashSet
+      peer1Batches.len == 2
+      peer2Batches.len == 2
+      peer1Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
+      peer2Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
+      peer1Sent == expectedPeer1
+      peer2Sent == expectedPeer2
+      sentAddresses.len == requestCount
+
+  test "Should dispatch timed-out batch for correct peer":
+    let
+      firstAddress = BlockAddress.init(blocks[0].cid)
+      secondAddress = BlockAddress.init(blocks[2].cid)
+      done = newAsyncEvent()
+
+    var dispatchedBatches: seq[tuple[peer: PeerId, addresses: seq[BlockAddress]]]
+
+    proc sendWantList(
+        id: PeerId,
+        addresses: seq[BlockAddress],
+        priority: int32 = 0,
+        cancel: bool = false,
+        wantType: WantType = WantType.WantHave,
+        full: bool = false,
+        sendDontHave: bool = false,
+    ) {.async: (raises: [CancelledError]).} =
+      if wantType == WantBlock:
+        dispatchedBatches.add((peer: id, addresses: addresses))
+        if not done.isSet:
+          done.fire()
+
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
+      )
+    )
+    peerCtx.setPresence(Presence(address: firstAddress, have: true))
+    peerCtx.setPresence(Presence(address: secondAddress, have: true))
+
+    check:
+      engine.requestDelivery(firstAddress).isOk
+      engine.requestDelivery(secondAddress).isOk
+
+    await done.wait().wait(100.millis)
+
+    check:
+      dispatchedBatches.len == 1
+      dispatchedBatches[0].peer == peerId
+      dispatchedBatches[0].addresses.len == 2
+      firstAddress in dispatchedBatches[0].addresses
+      secondAddress in dispatchedBatches[0].addresses
+
+    await engine.completeBlock(firstAddress, blocks[0])
+    await engine.completeBlock(secondAddress, blocks[2])
+
   test "Should keep same peer request after clearing previous request":
     let
       address = BlockAddress.init(blocks[0].cid)
@@ -655,6 +795,8 @@ asyncchecksuite "Block Download":
     ) {.async: (raises: [CancelledError]).} =
       if wantType == WantBlock:
         check addresses == @[address]
+        check engine.pendingBlocks.isRequested(address)
+        check not engine.pendingBlocks.isScheduled(address)
         sent.complete()
 
     engine.network = BlockExcNetwork(
@@ -675,7 +817,7 @@ asyncchecksuite "Block Download":
     check engine.pendingBlocks.retries(address) == retriesBefore
 
     discard await engine.requestQueue.get()
-    await engine.sendRequestBatch(@[address])
+    await engine.sendRequestBatch(peerId, @[address])
     await sent.wait(100.millis)
 
     check engine.pendingBlocks.isRequested(address)
@@ -722,8 +864,12 @@ asyncchecksuite "Block Download":
     )
 
     let pending = engine.requestDelivery(address).tryGet()
+    let retriesBefore = engine.pendingBlocks.retries(address)
 
     await wantHaveSent.wait().wait(100.millis)
+    check engine.pendingBlocks.retries(address) == retriesBefore
+    # No-spin guarantee: address was not immediately requeued after no-peer path
+    check address notin engine.requestQueue
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )
@@ -732,6 +878,7 @@ asyncchecksuite "Block Download":
     check address in engine.pendingBlocks
     check engine.pendingBlocks.isRequested(address)
     check not engine.pendingBlocks.isScheduled(address)
+    check engine.pendingBlocks.retries(address) == retriesBefore - 1
     check address in peerCtx.blocksRequested
     await pending.cancelAndWait()
     expect CancelledError:


### PR DESCRIPTION
This further refines batching, by splitting batches per peer before sending, not after the batch has been assembled.