### PR TITLE
Feat/request queue to pendingblks

### DIFF
--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -18,6 +18,8 @@ import pkg/libp2p
 import pkg/confutils
 import pkg/confutils/defs
 import pkg/stew/io2
+import pkg/questionable
+import pkg/questionable/results
 import pkg/kvstore
 import pkg/ethers except Rng
 
@@ -49,6 +51,7 @@ type
     repoStore: RepoStore
     maintenance: BlockMaintainer
     natTraversal: NatTraversal
+    discoveryStore: KVStore
     taskpool: Taskpool
 
   NodePrivateKey* = libp2p.PrivateKey # alias
@@ -112,20 +115,16 @@ proc start*(s: NodeServer) {.async.} =
 proc stop*(s: NodeServer) {.async.} =
   notice "Stopping node"
 
-  let res = await noCancel allFinishedFailed[void](
-    @[
-      s.restServer.stop(),
-      s.archivistNode.switch.stop(),
-      s.archivistNode.stop(),
-      s.repoStore.stop(),
-      s.maintenance.stop(),
-      s.natTraversal.stop(),
-    ]
-  )
+  await s.restServer.stop()
+  await s.archivistNode.stop()
+  await s.maintenance.stop()
+  await s.natTraversal.stop()
+  await s.repoStore.stop()
+  await s.archivistNode.switch.stop()
 
-  if res.failure.len > 0:
-    error "Failed to stop node", failures = res.failure.len
-    raiseAssert "Failed to stop node"
+  if not s.discoveryStore.isNil:
+    if err =? (await s.discoveryStore.close()).errorOption:
+      error "Failed to close discovery store", err = err.msg
 
   if not s.taskpool.isNil:
     s.taskpool.shutdown()
@@ -267,5 +266,6 @@ proc new*(
     repoStore: repoStore,
     maintenance: maintenance,
     natTraversal: natTraversal,
+    discoveryStore: discoveryStore,
     taskpool: tp,
   )

--- a/archivist/blockexchange/engine/advertiser.nim
+++ b/archivist/blockexchange/engine/advertiser.nim
@@ -9,6 +9,7 @@
 
 {.push raises: [].}
 
+import std/sequtils
 import pkg/chronos
 import pkg/libp2p/cid
 import pkg/libp2p/multicodec
@@ -35,6 +36,9 @@ declareGauge(archivist_inflight_advertise, "inflight advertise requests")
 const
   DefaultConcurrentAdvertRequests = 10
   DefaultAdvertiseLoopSleep = 30.minutes
+  DefaultMinAdvertisePeers = 16
+  DefaultAdvertiseRetrySleep = 30.seconds
+  DefaultAdvertiseRetryWindow = 10.minutes
 
 type Advertiser* = ref object of RootObj
   localStore*: BlockStore # Local block store for this instance
@@ -49,6 +53,11 @@ type Advertiser* = ref object of RootObj
 
   advertiseLocalStoreLoopSleep: Duration # Advertise loop sleep
   inFlightAdvReqs*: Table[Cid, Future[void]] # Inflight advertise requests
+  pendingAdvRetries: Table[Cid, Future[void]] # Delayed sparse retry tasks
+  minAdvertisePeers: int # Desired routing-table size before advertising
+  advertiseRetrySleep: Duration # Delay before retrying sparse startup advertise
+  advertiseRetryWindow: Duration # Startup window for sparse advertise retries
+  startedAt: Moment # Time advertiser started
 
 proc addCidToQueue(b: Advertiser, cid: Cid) {.async: (raises: [CancelledError]).} =
   if cid notin b.advertiseQueue:
@@ -105,6 +114,36 @@ proc advertiseLocalStoreLoop(b: Advertiser) {.async: (raises: []).} =
 
   info "Exiting advertise task loop"
 
+proc hasElapsed(since: Moment, dur: Duration): bool =
+  (Moment.now() - since) >= dur
+
+proc shouldRetryAdvertise(b: Advertiser): bool =
+  b.minAdvertisePeers > 0 and b.discovery.nodesDiscovered() < b.minAdvertisePeers and
+    not hasElapsed(b.startedAt, b.advertiseRetryWindow)
+
+proc delayedAdvertiseRetry(b: Advertiser, cid: Cid) {.async: (raises: []).} =
+  try:
+    await sleepAsync(b.advertiseRetrySleep)
+
+    if b.advertiserRunning and not hasElapsed(b.startedAt, b.advertiseRetryWindow):
+      trace "Requeueing advertisement retry",
+        cid, nodes = b.discovery.nodesDiscovered(), target = b.minAdvertisePeers
+      await b.addCidToQueue(cid)
+  except CancelledError:
+    trace "Cancelled sparse startup advertisement retry", cid
+  except CatchableError as exc:
+    warn "Sparse startup advertisement retry failed", cid, err = exc.msg
+  finally:
+    b.pendingAdvRetries.del(cid)
+
+proc scheduleAdvertiseRetry(b: Advertiser, cid: Cid) =
+  if cid in b.pendingAdvRetries:
+    return
+
+  let retry = b.delayedAdvertiseRetry(cid)
+  b.pendingAdvRetries[cid] = retry
+  b.trackedFutures.track(retry)
+
 proc processQueueLoop(b: Advertiser) {.async: (raises: []).} =
   try:
     while b.advertiserRunning:
@@ -117,13 +156,18 @@ proc processQueueLoop(b: Advertiser) {.async: (raises: []).} =
       b.inFlightAdvReqs[cid] = request
       archivist_inflight_advertise.set(b.inFlightAdvReqs.len.int64)
 
-      defer:
+      try:
+        await request
+      finally:
         b.inFlightAdvReqs.del(cid)
         archivist_inflight_advertise.set(b.inFlightAdvReqs.len.int64)
 
-      await request
+      if b.shouldRetryAdvertise():
+        b.scheduleAdvertiseRetry(cid)
   except CancelledError:
     warn "Cancelled advertise task runner"
+
+  await noCancel allFutures(toSeq(b.inFlightAdvReqs.values).mapIt(it.cancelAndWait()))
 
   info "Exiting advertise task runner"
 
@@ -135,7 +179,10 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
 
   # The advertiser is expected to be started only once.
   if b.advertiserRunning:
-    raiseAssert "Advertiser can only be started once - this should not happen"
+    warn "Advertiser can only be started once - this should not happen"
+    return
+
+  b.advertiserRunning = true
 
   proc onBlock(cid: Cid) {.async: (raises: []).} =
     try:
@@ -146,7 +193,7 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
   doAssert(b.localStore.onBlockStored.isNone())
   b.localStore.onBlockStored = onBlock.some
 
-  b.advertiserRunning = true
+  b.startedAt = Moment.now()
   for i in 0 ..< b.concurrentAdvReqs:
     let fut = b.processQueueLoop()
     b.trackedFutures.track(fut)
@@ -163,11 +210,12 @@ proc stop*(b: Advertiser) {.async: (raises: []).} =
     warn "Stopping advertiser without starting it"
     return
 
+  trace "Stopping advertise loop and tasks"
+  await b.trackedFutures.cancelTracked()
+
   b.advertiserRunning = false
   # Stop incoming tasks from callback and localStore loop
   b.localStore.onBlockStored = CidCallback.none
-  trace "Stopping advertise loop and tasks"
-  await b.trackedFutures.cancelTracked()
   trace "Advertiser loop and tasks stopped"
 
 proc new*(
@@ -176,6 +224,9 @@ proc new*(
     discovery: Discovery,
     concurrentAdvReqs = DefaultConcurrentAdvertRequests,
     advertiseLocalStoreLoopSleep = DefaultAdvertiseLoopSleep,
+    minAdvertisePeers = DefaultMinAdvertisePeers,
+    advertiseRetrySleep = DefaultAdvertiseRetrySleep,
+    advertiseRetryWindow = DefaultAdvertiseRetryWindow,
 ): Advertiser =
   ## Create a advertiser instance
   ##
@@ -186,5 +237,9 @@ proc new*(
     advertiseQueue: newAsyncQueue[Cid](concurrentAdvReqs),
     trackedFutures: TrackedFutures.new(),
     inFlightAdvReqs: initTable[Cid, Future[void]](),
+    pendingAdvRetries: initTable[Cid, Future[void]](),
     advertiseLocalStoreLoopSleep: advertiseLocalStoreLoopSleep,
+    minAdvertisePeers: minAdvertisePeers,
+    advertiseRetrySleep: advertiseRetrySleep,
+    advertiseRetryWindow: advertiseRetryWindow,
   )

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -7,6 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+import std/hashes
 import std/options
 import std/sequtils
 import std/sets
@@ -392,24 +393,22 @@ proc failBlockRequest(
   self.pendingBlocks.failWantHandle(address, errType, msg)
 
 proc sendRequestBatch(
-    self: BlockExcEngine, addresses: seq[BlockAddress]
+    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
   if addresses.len == 0:
+    trace "Cannot send empty batch", peerId
     return
 
-  var byPeer: Table[PeerId, seq[BlockAddress]]
-  for address in addresses.deduplicate():
-    var shouldRetry = false
+  let peer = self.peers.get(peerId)
+  if peer.isNil:
+    trace "Unable to find peer to send batch to", peerId
+    for address in addresses:
+      self.scheduleBlockSend(address)
+    return
 
-    defer:
-      self.pendingBlocks.clearScheduled(address)
-      self.pendingBlocks.decRetries(address)
-
-      if shouldRetry:
-        self.scheduleBlockSend(address)
-
+  var batch: seq[BlockAddress]
+  for address in addresses:
     if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
-      trace "Address is not pending or already requested", address
       continue
 
     if self.pendingBlocks.retriesExhausted(address):
@@ -420,77 +419,141 @@ proc sendRequestBatch(
       )
       continue
 
-    let peers = self.peers.getPeersForBlock(address)
-    if peers.with.len == 0 and peers.without.len > 0:
-      await self.refreshBlockKnowledge()
-
-    if peers.with.len == 0:
-      self.searchForNewPeers(address.cidOrTreeCid)
-      trace "No peer for block, discovery started and retry scheduled", address
-      shouldRetry = true
-      continue
-
-    let peer = self.selectPeer(peers.with)
-    if peer.isNil:
-      trace "No peer context, skipping", peer = peer.id
-      shouldRetry = true
-      continue
-
     let requested =
-      self.pendingBlocks.markRequested(address, peer.id, self.blockRequestTimeout)
-    if requested != peer.id.some:
+      self.pendingBlocks.markRequested(address, peerId, self.blockRequestTimeout)
+
+    if requested != peerId.some:
       trace "Block already requested from another peer", address, peer = requested.get
       continue
 
+    self.pendingBlocks.decRetries(address)
     peer.blockRequestScheduled(address)
-    byPeer.mgetOrPut(peer.id, @[]).add(address)
+    self.pendingBlocks.clearScheduled(address)
+    batch.add(address)
 
-  for peerId, batch in byPeer:
-    if batch.len == 0:
-      continue
+  if batch.len == 0:
+    trace "Batch is empty, skipping", peerId
+    return
 
-    if err =? catchAsync(await self.sendWantBlock(batch, peerId)).errorOption:
-      warn "Failed to send wantBlock batch", peer = peerId, err = err.msg
-      let peer = self.peers.get(peerId)
-      if not peer.isNil:
-        for address in batch:
-          await self.pendingBlocks.clearRequest(address, peerId)
-          peer.blockRequestCancelled(address)
-          peer.cleanPresence(address)
-          self.scheduleBlockSend(address)
-      continue
+  if err =? catchAsync(await self.sendWantBlock(batch, peerId)).errorOption:
+    warn "Failed to send wantBlock batch", peer = peerId, err = err.msg
+    for address in batch:
+      await self.pendingBlocks.clearRequest(address, peerId)
+      peer.blockRequestCancelled(address)
+      peer.cleanPresence(address)
+      self.scheduleBlockSend(address)
+
+proc sendRequestBatchTask(
+    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
+) {.async: (raises: []).} =
+  try:
+    await self.sendRequestBatch(peerId, addresses)
+  except CatchableError as exc:
+    trace "Exception sending batch", peerId
+
+type
+  BatchTimer = Future[void]
+  BatchReq = object
+    batch: seq[BlockAddress]
+    timer: BatchTimer
+
+func hash(timer: BatchTimer): Hash =
+  cast[pointer](timer).hash
 
 proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
+  var
+    byPeer: Table[PeerId, BatchReq]
+    timers: Table[Future[void], PeerId]
+
   try:
     while self.blockexcRunning:
-      var batch = @[await self.requestQueue.get()]
-      let timer = sleepAsync(DefaultWantBlockBatchTimeout)
-
+      var finished: FutureBase
+      let next = self.requestQueue.get()
       try:
-        while batch.len < self.wantBlockBatchSize:
-          let next = self.requestQueue.get()
-          try:
-            await next or timer
-          finally:
-            if not next.finished:
-              await noCancel next.cancelAndWait()
-
-          if not next.completed:
-            break
-
-          let address = await next
-          trace "Got block from request queue", address
-          batch.add(address)
-
-          if timer.finished:
-            break
+        finished = await FutureBase(next).race(timers.keys.toSeq.mapIt(FutureBase(it)))
       finally:
-        if not timer.finished:
-          await noCancel timer.cancelAndWait()
+        if not next.finished:
+          await noCancel next.cancelAndWait()
 
-      await self.sendRequestBatch(batch)
+      if not next.completed:
+        let batchTimer = BatchTimer(finished)
+        if peerId =? timers .? [batchTimer]:
+          timers.del(batchTimer)
+          if batchReq =? byPeer .? [peerId]:
+            byPeer.del(peerId)
+            if batchReq.batch.len > 0:
+              self.trackedFutures.track(
+                self.sendRequestBatchTask(peerId, batchReq.batch)
+              )
+              trace "Request batch task dispatched after timeout deadline",
+                peerId, batch = batchReq.batch.len
+          else:
+            warn "No peer found for timer", peerId
+        continue
+
+      let address = await next
+      trace "Got block from request queue", address
+
+      var shouldRetry = false
+      defer:
+        if shouldRetry:
+          self.pendingBlocks.clearScheduled(address)
+          self.scheduleBlockSend(address)
+
+      if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
+        trace "Address is not pending or already requested", address
+        shouldRetry = true
+        continue
+
+      if self.pendingBlocks.retriesExhausted(address):
+        trace "Retries exhausted, skipping block", address
+        archivist_block_exchange_requests_failed_total.inc()
+        await self.failBlockRequest(
+          address, RetriesExhaustedEngineError, "Block request retries exhausted"
+        )
+        continue
+
+      let peers = self.peers.getPeersForBlock(address)
+      if peers.with.len == 0 and peers.without.len > 0:
+        await self.refreshBlockKnowledge()
+
+      if peers.with.len == 0:
+        self.searchForNewPeers(address.cidOrTreeCid)
+        trace "No peer for block, discovery started and retry scheduled", address
+        shouldRetry = true
+        continue
+
+      let peer = self.selectPeer(peers.with)
+      if peer.isNil:
+        trace "No peer context, skipping", address
+        shouldRetry = true
+        continue
+
+      var peerBatch: seq[BlockAddress]
+      byPeer.withValue(peer.id, req):
+        req[].batch.add(address)
+        peerBatch = req[].batch
+      do:
+        let timer = sleepAsync(DefaultWantBlockBatchTimeout)
+        byPeer[peer.id] = BatchReq(batch: @[address], timer: timer)
+        timers[timer] = peer.id
+        continue
+
+      if peerBatch.len >= self.wantBlockBatchSize:
+        if batchReq =? byPeer .? [peer.id]:
+          let batchTimer = BatchTimer(batchReq.timer)
+          await noCancel batchTimer.cancelAndWait()
+          timers.del(batchTimer)
+          byPeer.del(peer.id)
+          self.trackedFutures.track(self.sendRequestBatchTask(peer.id, peerBatch))
   except CancelledError:
+    byPeer.clear()
+    timers.clear()
     warn "Request scheduling cancelled!"
+
+  for timer in timers.keys.toSeq:
+    if not timer.finished:
+      await noCancel timer.cancelAndWait()
 
   trace "Block request scheduling stopped"
 

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -480,7 +480,7 @@ proc blocksDeliveryHandler*(
         if not peerCtx.isNil:
           peerCtx.cleanPresence(bd.address)
         await self.pendingBlocks.retryAddresses(
-          @[bd.address], DefaultBlockSendRetryDelay
+          @[bd.address], self.pendingBlocks.blockSendTimeout
         )
         continue
 
@@ -531,7 +531,9 @@ proc blocksDeliveryHandler*(
       error "Unable to decode manifest block", err = err.msg
       if not peerCtx.isNil:
         peerCtx.cleanPresence(bd.address)
-      await self.pendingBlocks.retryAddresses(@[bd.address], DefaultBlockSendRetryDelay)
+      await self.pendingBlocks.retryAddresses(
+        @[bd.address], self.pendingBlocks.blockSendTimeout
+      )
       validatedBlocksDelivery.keepItIf(it.address.cid != bd.address.cid)
       continue
 

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -107,6 +107,7 @@ type
     maxBlocksPerMessage: int
     wantBlockBatchSize: int
     wantBlockBatchTimeout: Duration
+    discoveryDeadline*: Duration
     blockRequestTimeout: Duration
     pendingBlocks*: PendingBlocksManager
     discovery*: DiscoveryEngine
@@ -278,7 +279,6 @@ proc scheduleBlockSend(
   address: BlockAddress,
   immediate = false,
   delay = DefaultBlockSendRetryDelay,
-  forceDelay = false,
 ) {.gcsafe, raises: [].}
 
 proc failBlockRequest(
@@ -322,7 +322,6 @@ proc scheduleBlockSendTask(
     address: BlockAddress,
     immediate: bool,
     delay = DefaultBlockSendRetryDelay,
-    forceDelay = false,
 ) {.async: (raises: []).} =
   without handle =? self.pendingBlocks.getPendingHandle(address):
     self.pendingBlocks.clearScheduled(address)
@@ -338,7 +337,7 @@ proc scheduleBlockSendTask(
     )
     return
 
-  if forceDelay or (not immediate and not self.pendingBlocks.isFirstAttempt(address)):
+  if not immediate and not self.pendingBlocks.isFirstAttempt(address):
     let timer = sleepAsync(delay)
     try:
       await handle or timer
@@ -366,11 +365,8 @@ proc scheduleBlockSend(
     address: BlockAddress,
     immediate = false,
     delay = DefaultBlockSendRetryDelay,
-    forceDelay = false,
 ) {.gcsafe, raises: [].} =
-  self.trackedFutures.track(
-    self.scheduleBlockSendTask(address, immediate, delay, forceDelay)
-  )
+  self.trackedFutures.track(self.scheduleBlockSendTask(address, immediate, delay))
 
 proc clearBlockRequestState(
     self: BlockExcEngine, address: BlockAddress
@@ -512,16 +508,14 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
 
       if peers.with.len == 0:
         self.searchForNewPeers(address.cidOrTreeCid)
-        self.pendingBlocks.clearScheduled(address)
-        self.scheduleBlockSend(address, forceDelay = true)
-        trace "No peer for block, discovery started and retry scheduled", address
+        self.pendingBlocks.enterDiscoveryWait(address, self.discoveryDeadline)
+        trace "No peer for block, entering discovery wait", address
         continue
 
       let peer = self.selectPeer(peers.with)
       if peer.isNil:
-        trace "No peer context, skipping", address
-        self.pendingBlocks.clearScheduled(address)
-        self.scheduleBlockSend(address, forceDelay = true)
+        trace "No peer context, entering discovery wait", address
+        self.pendingBlocks.enterDiscoveryWait(address, self.discoveryDeadline)
         continue
 
       var peerBatch: seq[BlockAddress]
@@ -609,7 +603,7 @@ proc blockPresenceHandler*(
   for address in ourWantList:
     if address in peerHave and not self.pendingBlocks.retriesExhausted(address) and
         not self.pendingBlocks.isRequested(address):
-      self.scheduleBlockSend(address, immediate = true)
+      self.pendingBlocks.wakeOnPresence(address)
 
 proc scheduleTasks(
     self: BlockExcEngine, blocksDelivery: seq[BlockDelivery]

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -82,7 +82,7 @@ declareCounter(
 const
   DefaultTaskQueueSize = 128
   DefaultConcurrentTasks = 3
-  DefaultWantBlockBatchSize = 128
+  DefaultWantBlockBatchSize = DefaultMaxBatchBlocks
   DefaultWantBlockBatchTimeout = 5.millis
   DiscoveryRateLimit = 3.seconds
   PresenceBatchSize = DefaultMaxWantListBatchSize
@@ -104,8 +104,6 @@ type
     trackedFutures: TrackedFutures
     blockexcRunning: bool
     maxBatchBlocks: int
-    wantBlockBatchSize: int
-    wantBlockBatchTimeout: Duration
     discoveryDeadline*: Duration
     blockRequestTimeout: Duration
     pendingBlocks*: PendingBlocksManager
@@ -739,8 +737,6 @@ proc new*(
     maxBatchBlocks = DefaultMaxBatchBlocks,
     concurrentTasks = DefaultConcurrentTasks,
     selectPeer: PeerSelector = randomPeer,
-    wantBlockBatchSize = DefaultWantBlockBatchSize,
-    wantBlockBatchTimeout = DefaultWantBlockBatchTimeout,
     blockRequestTimeout = DefaultRequestTimeout,
 ): BlockExcEngine =
   let self = BlockExcEngine(
@@ -751,8 +747,6 @@ proc new*(
     concurrentTasks: concurrentTasks,
     trackedFutures: TrackedFutures(),
     maxBatchBlocks: maxBatchBlocks,
-    wantBlockBatchSize: wantBlockBatchSize,
-    wantBlockBatchTimeout: wantBlockBatchTimeout,
     blockRequestTimeout: blockRequestTimeout,
     taskQueue: newAsyncHeapQueue[BlockExcPeerCtx](DefaultTaskQueueSize),
     discovery: discovery,

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -108,6 +108,7 @@ type
     blockexcRunning: bool
     maxBlocksPerMessage: int
     wantBlockBatchSize: int
+    wantBlockBatchTimeout: Duration
     blockRequestTimeout: Duration
     pendingBlocks*: PendingBlocksManager
     discovery*: DiscoveryEngine
@@ -535,7 +536,7 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
         req[].batch.add(address)
         peerBatch = req[].batch
       do:
-        let timer = sleepAsync(DefaultWantBlockBatchTimeout)
+        let timer = sleepAsync(self.wantBlockBatchTimeout)
         byPeer[peer.id] = BatchReq(batch: @[address], timer: timer)
         timers[timer] = peer.id
         continue
@@ -1021,6 +1022,8 @@ proc new*(
     maxBlocksPerMessage = DefaultMaxBlocksPerMessage,
     concurrentTasks = DefaultConcurrentTasks,
     selectPeer: PeerSelector = randomPeer,
+    wantBlockBatchSize = DefaultWantBlockBatchSize,
+    wantBlockBatchTimeout = DefaultWantBlockBatchTimeout,
     blockRequestTimeout = DefaultRequestTimeout,
 ): BlockExcEngine =
   let self = BlockExcEngine(
@@ -1031,7 +1034,8 @@ proc new*(
     concurrentTasks: concurrentTasks,
     trackedFutures: TrackedFutures(),
     maxBlocksPerMessage: maxBlocksPerMessage,
-    wantBlockBatchSize: DefaultWantBlockBatchSize,
+    wantBlockBatchSize: wantBlockBatchSize,
+    wantBlockBatchTimeout: wantBlockBatchTimeout,
     blockRequestTimeout: blockRequestTimeout,
     taskQueue: newAsyncHeapQueue[BlockExcPeerCtx](DefaultTaskQueueSize),
     requestQueue: newAsyncQueue[BlockAddress](DefaultRequestQueueSize),

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -88,7 +88,6 @@ const
   DiscoveryRateLimit = 3.seconds
   PresenceBatchSize = DefaultMaxWantListBatchSize
   CleanupBatchSize = 2048
-  DefaultRequestQueueSize = DefaultWantBlockBatchSize
 
 type
   TaskHandler* = proc(task: BlockExcPeerCtx): Future[void] {.gcsafe.}
@@ -101,7 +100,6 @@ type
     network*: BlockExcNetwork
     peers*: PeerCtxStore
     taskQueue*: AsyncHeapQueue[BlockExcPeerCtx]
-    requestQueue*: AsyncQueue[BlockAddress]
     selectPeer*: PeerSelector
     concurrentTasks: int
     trackedFutures: TrackedFutures
@@ -340,9 +338,6 @@ proc scheduleBlockSendTask(
     )
     return
 
-  if not self.pendingBlocks.markScheduled(address):
-    return
-
   if forceDelay or (not immediate and not self.pendingBlocks.isFirstAttempt(address)):
     let timer = sleepAsync(delay)
     try:
@@ -357,17 +352,14 @@ proc scheduleBlockSendTask(
       trace "Handle finished before queueing block", address
       return
 
-  let putFut = self.requestQueue.put(address)
+  let enqueueFut = self.pendingBlocks.enqueue(address, 0)
   try:
-    await handle or putFut
+    await handle or enqueueFut
   except CatchableError as exc:
     trace "Exception queuing block for send", address, exc = exc.msg
   finally:
-    if handle.finished and not putFut.finished:
-      await noCancel putFut.cancelAndWait()
-
-  if handle.finished or not putFut.completed:
-    self.pendingBlocks.clearScheduled(address)
+    if handle.finished and not enqueueFut.finished:
+      await noCancel enqueueFut.cancelAndWait()
 
 proc scheduleBlockSend(
     self: BlockExcEngine,
@@ -409,6 +401,7 @@ proc sendRequestBatch(
   if peer.isNil:
     trace "Unable to find peer to send batch to", peerId
     for address in addresses:
+      self.pendingBlocks.clearScheduled(address)
       self.scheduleBlockSend(address)
     return
 
@@ -474,7 +467,7 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
   try:
     while self.blockexcRunning:
       var finished: FutureBase
-      let next = self.requestQueue.get()
+      let next = self.pendingBlocks.dequeue()
       try:
         finished = await FutureBase(next).race(timers.keys.toSeq.mapIt(FutureBase(it)))
       finally:
@@ -1038,7 +1031,6 @@ proc new*(
     wantBlockBatchTimeout: wantBlockBatchTimeout,
     blockRequestTimeout: blockRequestTimeout,
     taskQueue: newAsyncHeapQueue[BlockExcPeerCtx](DefaultTaskQueueSize),
-    requestQueue: newAsyncQueue[BlockAddress](DefaultRequestQueueSize),
     discovery: discovery,
     advertiser: advertiser,
     selectPeer: selectPeer,

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -12,6 +12,7 @@ import std/options
 import std/sequtils
 import std/sets
 import std/tables
+import std/strformat
 
 import pkg/chronos
 import pkg/libp2p/[cid, switch, multihash, multicodec]
@@ -81,10 +82,8 @@ declareCounter(
 const
   DefaultTaskQueueSize = 128
   DefaultConcurrentTasks = 3
-  DefaultMaxBlocksPerMessage = 128
   DefaultWantBlockBatchSize = 128
   DefaultWantBlockBatchTimeout = 5.millis
-  DefaultBlockSendRetryDelay = 500.millis
   DiscoveryRateLimit = 3.seconds
   PresenceBatchSize = DefaultMaxWantListBatchSize
   CleanupBatchSize = 2048
@@ -104,7 +103,7 @@ type
     concurrentTasks: int
     trackedFutures: TrackedFutures
     blockexcRunning: bool
-    maxBlocksPerMessage: int
+    maxBatchBlocks: int
     wantBlockBatchSize: int
     wantBlockBatchTimeout: Duration
     discoveryDeadline*: Duration
@@ -121,7 +120,6 @@ proc scheduleTask(self: BlockExcEngine, task: BlockExcPeerCtx) {.gcsafe, raises:
     warn "Unable to schedule task for peer", peer = task.id
 
 proc blockexcTaskRunner(self: BlockExcEngine) {.async: (raises: []).}
-proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).}
 proc resolveBlocks*(
   self: BlockExcEngine, blocksDelivery: seq[BlockDelivery]
 ) {.async: (raises: [CancelledError]).}
@@ -140,7 +138,7 @@ proc start*(self: BlockExcEngine) {.async: (raises: []).} =
   for i in 0 ..< self.concurrentTasks:
     self.trackedFutures.track(self.blockexcTaskRunner())
 
-  self.trackedFutures.track(self.blockRequestScheduler())
+  self.trackedFutures.track(self.pendingBlocks.start())
 
 proc stop*(self: BlockExcEngine) {.async: (raises: []).} =
   if not self.blockexcRunning:
@@ -149,7 +147,7 @@ proc stop*(self: BlockExcEngine) {.async: (raises: []).} =
 
   self.blockexcRunning = false
   await self.trackedFutures.cancelTracked()
-  await self.pendingBlocks.cancelAll()
+  await self.pendingBlocks.stop()
   await self.network.stop()
   await self.discovery.stop()
   await self.advertiser.stop()
@@ -274,20 +272,6 @@ proc refreshBlockKnowledge(self: BlockExcEngine) {.async: (raises: [CancelledErr
 
       lastIdle = Moment.now()
 
-proc scheduleBlockSend(
-  self: BlockExcEngine,
-  address: BlockAddress,
-  immediate = false,
-  delay = DefaultBlockSendRetryDelay,
-) {.gcsafe, raises: [].}
-
-proc failBlockRequest(
-  self: BlockExcEngine,
-  address: BlockAddress,
-  errType: typedesc[EngineError],
-  msg: string,
-) {.async: (raises: []).}
-
 proc searchForNewPeers(self: BlockExcEngine, cid: Cid) =
   if self.lastDiscRequest + DiscoveryRateLimit < Moment.now():
     archivist_block_exchange_discovery_requests_total.inc()
@@ -296,86 +280,11 @@ proc searchForNewPeers(self: BlockExcEngine, cid: Cid) =
 
 proc evictPeer(self: BlockExcEngine, peer: PeerId) {.gcsafe, async: (raises: []).} =
   trace "Evicting disconnected/departed peer", peer
-
-  var
-    pendingAddresses: seq[BlockAddress]
-    requests: seq[Future[void]]
-
-  let peerCtx = self.peers.get(peer)
-  if not peerCtx.isNil:
-    for address in peerCtx.blocksRequested:
-      pendingAddresses.add(address)
-      requests.add(self.pendingBlocks.clearRequest(address, peer))
-
-    await noCancel allFutures(requests)
-
+  # Just remove from store -- disconnect monitor in PendingBlocksManager handles requeue
   self.peers.remove(peer)
-  for address in pendingAddresses:
-    if address in self.pendingBlocks:
-      self.scheduleBlockSend(address)
 
 proc randomPeer(peers: seq[BlockExcPeerCtx]): BlockExcPeerCtx =
   Rng.instance.sample(peers)
-
-proc scheduleBlockSendTask(
-    self: BlockExcEngine,
-    address: BlockAddress,
-    immediate: bool,
-    delay = DefaultBlockSendRetryDelay,
-) {.async: (raises: []).} =
-  without handle =? self.pendingBlocks.getPendingHandle(address):
-    self.pendingBlocks.clearScheduled(address)
-    return
-
-  if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
-    return
-
-  if self.pendingBlocks.retriesExhausted(address):
-    archivist_block_exchange_requests_failed_total.inc()
-    self.pendingBlocks.failWantHandle(
-      address, RetriesExhaustedEngineError, "Block request retries exhausted"
-    )
-    return
-
-  if not immediate and not self.pendingBlocks.isFirstAttempt(address):
-    let timer = sleepAsync(delay)
-    try:
-      await handle or timer
-    except CatchableError as exc:
-      trace "Exception in scheduling block send task", address, exc = exc.msg
-    finally:
-      if not timer.finished:
-        await noCancel timer.cancelAndWait()
-
-    if handle.finished:
-      trace "Handle finished before queueing block", address
-      return
-
-  let enqueueFut = self.pendingBlocks.enqueue(address, 0)
-  try:
-    await handle or enqueueFut
-  except CatchableError as exc:
-    trace "Exception queuing block for send", address, exc = exc.msg
-  finally:
-    if handle.finished and not enqueueFut.finished:
-      await noCancel enqueueFut.cancelAndWait()
-
-proc scheduleBlockSend(
-    self: BlockExcEngine,
-    address: BlockAddress,
-    immediate = false,
-    delay = DefaultBlockSendRetryDelay,
-) {.gcsafe, raises: [].} =
-  self.trackedFutures.track(self.scheduleBlockSendTask(address, immediate, delay))
-
-proc clearBlockRequestState(
-    self: BlockExcEngine, address: BlockAddress
-) {.async: (raises: []).} =
-  if peerId =? self.pendingBlocks.getRequestPeer(address):
-    let ctx = self.peers.get(peerId)
-    if not ctx.isNil:
-      ctx.blockRequestCancelled(address)
-  await self.pendingBlocks.clearRequest(address)
 
 proc failBlockRequest(
     self: BlockExcEngine,
@@ -383,168 +292,7 @@ proc failBlockRequest(
     errType: typedesc[EngineError],
     msg: string,
 ) {.async: (raises: []).} =
-  await self.clearBlockRequestState(address)
-  self.pendingBlocks.failWantHandle(address, errType, msg)
-
-proc sendRequestBatch(
-    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
-) {.async: (raises: [CancelledError]).} =
-  if addresses.len == 0:
-    trace "Cannot send empty batch", peerId
-    return
-
-  let peer = self.peers.get(peerId)
-  if peer.isNil:
-    trace "Unable to find peer to send batch to", peerId
-    for address in addresses:
-      self.pendingBlocks.clearScheduled(address)
-      self.scheduleBlockSend(address)
-    return
-
-  var batch: seq[BlockAddress]
-  for address in addresses:
-    if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
-      continue
-
-    if self.pendingBlocks.retriesExhausted(address):
-      trace "Retries exhausted, skipping block", address
-      archivist_block_exchange_requests_failed_total.inc()
-      await self.failBlockRequest(
-        address, RetriesExhaustedEngineError, "Block request retries exhausted"
-      )
-      continue
-
-    let requested =
-      self.pendingBlocks.markRequested(address, peerId, self.blockRequestTimeout)
-
-    if requested != peerId.some:
-      trace "Block already requested from another peer", address, peer = requested.get
-      continue
-
-    self.pendingBlocks.decRetries(address)
-    peer.blockRequestScheduled(address)
-    self.pendingBlocks.clearScheduled(address)
-    batch.add(address)
-
-  if batch.len == 0:
-    trace "Batch is empty, skipping", peerId
-    return
-
-  if err =? catchAsync(await self.sendWantBlock(batch, peerId)).errorOption:
-    warn "Failed to send wantBlock batch", peer = peerId, err = err.msg
-    for address in batch:
-      await self.pendingBlocks.clearRequest(address, peerId)
-      peer.blockRequestCancelled(address)
-      peer.cleanPresence(address)
-      self.scheduleBlockSend(address)
-
-proc sendRequestBatchTask(
-    self: BlockExcEngine, peerId: PeerId, addresses: seq[BlockAddress]
-) {.async: (raises: []).} =
-  try:
-    await self.sendRequestBatch(peerId, addresses)
-  except CatchableError as exc:
-    trace "Exception sending batch", peerId
-
-type
-  BatchTimer = Future[void]
-  BatchReq = object
-    batch: seq[BlockAddress]
-    timer: BatchTimer
-
-func hash(timer: BatchTimer): Hash =
-  cast[pointer](timer).hash
-
-proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
-  var
-    byPeer: Table[PeerId, BatchReq]
-    timers: Table[Future[void], PeerId]
-
-  try:
-    while self.blockexcRunning:
-      var finished: FutureBase
-      let next = self.pendingBlocks.dequeue()
-      try:
-        finished = await FutureBase(next).race(timers.keys.toSeq.mapIt(FutureBase(it)))
-      finally:
-        if not next.finished:
-          await noCancel next.cancelAndWait()
-
-      if not next.completed:
-        let batchTimer = BatchTimer(finished)
-        if peerId =? timers .? [batchTimer]:
-          timers.del(batchTimer)
-          if batchReq =? byPeer .? [peerId]:
-            byPeer.del(peerId)
-            if batchReq.batch.len > 0:
-              self.trackedFutures.track(
-                self.sendRequestBatchTask(peerId, batchReq.batch)
-              )
-              trace "Request batch task dispatched after timeout deadline",
-                peerId, batch = batchReq.batch.len
-          else:
-            warn "No peer found for timer", peerId
-        continue
-
-      let address = await next
-      trace "Got block from request queue", address
-
-      if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
-        trace "Address is not pending or already requested", address
-        self.pendingBlocks.clearScheduled(address)
-        continue
-
-      if self.pendingBlocks.retriesExhausted(address):
-        trace "Retries exhausted, skipping block", address
-        archivist_block_exchange_requests_failed_total.inc()
-        await self.failBlockRequest(
-          address, RetriesExhaustedEngineError, "Block request retries exhausted"
-        )
-        continue
-
-      let peers = self.peers.getPeersForBlock(address)
-      if peers.with.len == 0 and peers.without.len > 0:
-        await self.refreshBlockKnowledge()
-
-      if peers.with.len == 0:
-        self.searchForNewPeers(address.cidOrTreeCid)
-        self.pendingBlocks.enterDiscoveryWait(address, self.discoveryDeadline)
-        trace "No peer for block, entering discovery wait", address
-        continue
-
-      let peer = self.selectPeer(peers.with)
-      if peer.isNil:
-        trace "No peer context, entering discovery wait", address
-        self.pendingBlocks.enterDiscoveryWait(address, self.discoveryDeadline)
-        continue
-
-      var peerBatch: seq[BlockAddress]
-      byPeer.withValue(peer.id, req):
-        req[].batch.add(address)
-        peerBatch = req[].batch
-      do:
-        let timer = sleepAsync(self.wantBlockBatchTimeout)
-        byPeer[peer.id] = BatchReq(batch: @[address], timer: timer)
-        timers[timer] = peer.id
-        continue
-
-      if peerBatch.len >= self.wantBlockBatchSize:
-        if batchReq =? byPeer .? [peer.id]:
-          let batchTimer = BatchTimer(batchReq.timer)
-          await noCancel batchTimer.cancelAndWait()
-          timers.del(batchTimer)
-          byPeer.del(peer.id)
-          self.trackedFutures.track(self.sendRequestBatchTask(peer.id, peerBatch))
-  except CancelledError:
-    byPeer.clear()
-    timers.clear()
-    warn "Request scheduling cancelled!"
-
-  for timer in timers.keys.toSeq:
-    if not timer.finished:
-      await noCancel timer.cancelAndWait()
-
-  trace "Block request scheduling stopped"
+  await self.pendingBlocks.failWantHandle(address, errType, msg)
 
 proc requestDeliveries*(
     self: BlockExcEngine, addresses: seq[BlockAddress], priority = 0
@@ -552,18 +300,14 @@ proc requestDeliveries*(
   var handles: seq[BlockHandle]
 
   for address in addresses.deduplicate():
-    let handle = self.pendingBlocks.getWantHandle(address)
-    self.scheduleBlockSend(address)
-    handles.add(handle)
+    handles.add(self.pendingBlocks.getWantHandle(address, priority = priority))
 
   success handles
 
 proc requestDelivery*(
     self: BlockExcEngine, address: BlockAddress, priority = 0
 ): ?!BlockHandle =
-  let handle = self.pendingBlocks.getWantHandle(address)
-  self.scheduleBlockSend(address)
-  success handle
+  success self.pendingBlocks.getWantHandle(address, priority = priority)
 
 proc completeBlocks*(
     self: BlockExcEngine, blocksDelivery: seq[BlockDelivery]
@@ -600,10 +344,13 @@ proc blockPresenceHandler*(
   if dontWantCids.len > 0:
     peerCtx.cleanPresence(dontWantCids.toSeq)
 
+  var toRetry: seq[BlockAddress]
   for address in ourWantList:
-    if address in peerHave and not self.pendingBlocks.retriesExhausted(address) and
-        not self.pendingBlocks.isRequested(address):
-      self.pendingBlocks.wakeOnPresence(address)
+    if address in peerHave and not self.pendingBlocks.retriesExhausted(address):
+      toRetry.add(address)
+
+  if toRetry.len > 0:
+    await self.pendingBlocks.retryAddresses(toRetry, 0.seconds)
 
 proc scheduleTasks(
     self: BlockExcEngine, blocksDelivery: seq[BlockDelivery]
@@ -617,7 +364,7 @@ proc scheduleTasks(
 proc cancelBlocks(
     self: BlockExcEngine, addrs: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
-  let blocksDelivered = toHashSet(addrs)
+  let toCancell = toHashSet(addrs)
   var scheduledCancellations: Table[PeerId, HashSet[BlockAddress]]
 
   if self.peers.len == 0:
@@ -629,49 +376,32 @@ proc cancelBlocks(
     await self.network.request.sendWantCancellations(peerId, addresses.toSeq)
     peerId
 
-  try:
-    for peerCtx in self.peers.peers.values:
-      let intersection = peerCtx.blocksRequested.intersection(blocksDelivered)
-      if intersection.len > 0:
-        scheduledCancellations[peerCtx.id] = intersection
-        peerCtx.cleanPresence(addrs)
-        for address in intersection:
-          peerCtx.blockRequestCancelled(address)
+  for peerCtx in self.peers.peers.values:
+    let intersection = peerCtx.blocksRequested.intersection(toCancell)
+    if intersection.len > 0:
+      scheduledCancellations[peerCtx.id] = intersection
+      peerCtx.cleanPresence(addrs)
 
-    if scheduledCancellations.len == 0:
-      return
+  if scheduledCancellations.len == 0:
+    return
 
-    var futures: seq[Future[PeerId]]
-    for peerId, addresses in scheduledCancellations:
-      futures.add(dispatchCancellations(peerId, addresses))
+  var futures: seq[Future[PeerId]]
+  for peerId, addresses in scheduledCancellations:
+    futures.add(dispatchCancellations(peerId, addresses))
 
-    let (_, failedFuts) = await allFinishedFailed[PeerId](futures)
-    if failedFuts.len > 0:
-      warn "Failed to send block request cancellations to peers", peers = failedFuts.len
-  except CancelledError as exc:
-    warn "Error sending block request cancellations", error = exc.msg
-    raise exc
-  except CatchableError as exc:
-    warn "Error sending block request cancellations", error = exc.msg
+  let (_, failedFuts) = await allFinishedFailed[PeerId](futures)
+  if failedFuts.len > 0:
+    warn "Failed to send block request cancellations to peers", peers = failedFuts.len
 
 proc releaseHandle*(
     self: BlockExcEngine, handle: BlockHandle
 ): Future[void] {.async: (raises: [CancelledError]).} =
-  let requested = self.pendingBlocks.getRequestPeer(handle)
-
-  if address =? self.pendingBlocks.getHandleAddress(handle):
-    await noCancel handle.cancelAndWait()
-
-    await self.cancelBlocks(@[address])
-    if peerId =? requested:
-      let ctx = self.peers.get(peerId)
-      if not ctx.isNil:
-        ctx.blockRequestCancelled(address)
+  await noCancel handle.cancelAndWait()
 
 proc resolveBlocks*(
     self: BlockExcEngine, blocksDelivery: seq[BlockDelivery]
 ) {.async: (raises: [CancelledError]).} =
-  self.pendingBlocks.resolve(blocksDelivery)
+  await self.pendingBlocks.resolve(blocksDelivery)
   await self.scheduleTasks(blocksDelivery)
   await self.cancelBlocks(blocksDelivery.mapIt(it.address))
 
@@ -748,10 +478,10 @@ proc blocksDeliveryHandler*(
       if err =? self.validateBlockDelivery(bd).errorOption:
         warn "Block validation failed", msg = err.msg
         if not peerCtx.isNil:
-          peerCtx.blockRequestCancelled(bd.address)
           peerCtx.cleanPresence(bd.address)
-        await self.pendingBlocks.clearRequest(bd.address, peer)
-        self.scheduleBlockSend(bd.address)
+        await self.pendingBlocks.retryAddresses(
+          @[bd.address], DefaultBlockSendRetryDelay
+        )
         continue
 
       if bd.address.leaf:
@@ -800,10 +530,8 @@ proc blocksDeliveryHandler*(
     without manifest =? Manifest.decode(bd.blk), err:
       error "Unable to decode manifest block", err = err.msg
       if not peerCtx.isNil:
-        peerCtx.blockRequestCancelled(bd.address)
         peerCtx.cleanPresence(bd.address)
-      await self.pendingBlocks.clearRequest(bd.address, peer)
-      self.scheduleBlockSend(bd.address)
+      await self.pendingBlocks.retryAddresses(@[bd.address], DefaultBlockSendRetryDelay)
       validatedBlocksDelivery.keepItIf(it.address.cid != bd.address.cid)
       continue
 
@@ -818,8 +546,8 @@ proc blocksDeliveryHandler*(
 
   if not peerCtx.isNil:
     for address in acceptedAddresses:
-      peerCtx.blockRequestAccepted(address)
-      await self.pendingBlocks.clearRequest(address, peer)
+      peerCtx.cleanPresence(address)
+      await self.pendingBlocks.clearRequest(address, peerCtx)
 
   archivist_block_exchange_blocks_received.inc(validatedBlocksDelivery.len.int64)
 
@@ -972,7 +700,7 @@ proc taskHandler*(
     if blockDeliveries.len == 0:
       return
 
-    for batch in blockDeliveries.batches(self.maxBlocksPerMessage):
+    for batch in blockDeliveries.batches(self.maxBatchBlocks):
       await self.network.request.sendBlocksDelivery(peerCtx.id, batch)
       archivist_block_exchange_blocks_sent.inc(batch.len.int64)
       for delivery in batch:
@@ -1006,7 +734,7 @@ proc new*(
     advertiser: Advertiser,
     peerStore: PeerCtxStore,
     pendingBlocks: PendingBlocksManager,
-    maxBlocksPerMessage = DefaultMaxBlocksPerMessage,
+    maxBatchBlocks = DefaultMaxBatchBlocks,
     concurrentTasks = DefaultConcurrentTasks,
     selectPeer: PeerSelector = randomPeer,
     wantBlockBatchSize = DefaultWantBlockBatchSize,
@@ -1020,7 +748,7 @@ proc new*(
     network: network,
     concurrentTasks: concurrentTasks,
     trackedFutures: TrackedFutures(),
-    maxBlocksPerMessage: maxBlocksPerMessage,
+    maxBatchBlocks: maxBatchBlocks,
     wantBlockBatchSize: wantBlockBatchSize,
     wantBlockBatchTimeout: wantBlockBatchTimeout,
     blockRequestTimeout: blockRequestTimeout,
@@ -1038,20 +766,62 @@ proc new*(
     else:
       await self.evictPeer(peerId)
 
-  proc pendingAbandonHandler(address: BlockAddress) {.gcsafe, async: (raises: []).} =
+  proc onAbandonHandler(
+      address: BlockAddress
+  ) {.gcsafe, async: (raises: [CancelledError]).} =
     trace "Running abandon block hook", address
-    await self.clearBlockRequestState(address)
+    await self.cancelBlocks(@[address])
 
-  proc pendingTimeoutHandler(
+  proc onTimeoutHandler(
       address: BlockAddress, peer: PeerId
-  ) {.gcsafe, async: (raises: []).} =
+  ) {.gcsafe, async: (raises: [CancelledError]).} =
     trace "Block request timed out", address, peer
     archivist_block_exchange_peer_timeouts_total.inc()
     self.network.dropPeer(peer)
-    await self.evictPeer(peer)
 
-  pendingBlocks.onAbandon = pendingAbandonHandler
-  pendingBlocks.onTimeout = pendingTimeoutHandler
+  proc pendingPeerSelector(
+      address: BlockAddress
+  ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+    var peers = self.peers.getPeersForBlock(address)
+    if peers.with.len == 0 and peers.without.len > 0:
+      await self.refreshBlockKnowledge()
+      peers = self.peers.getPeersForBlock(address)
+
+    if peers.with.len == 0:
+      self.searchForNewPeers(address.cidOrTreeCid)
+      trace "No peer for block", address
+      return
+        failure(newException(NoPeerForBlockError, fmt"No peer for block {address}"))
+
+    let peer = self.selectPeer(peers.with)
+    if peer.isNil:
+      self.searchForNewPeers(address.cidOrTreeCid)
+      trace "No peer context for block", address
+      return failure(
+        newException(NoPeerForBlockError, fmt"Unable to select suitable peer {address}")
+      )
+
+    success peer
+
+  proc onBatchReadyHandler(
+      peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+  ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+    if peer.isNil or batch.len == 0:
+      trace "Either peer is missing or batch is empty",
+        peerIsNil = peer.isNil, batch = batch.len
+      return success()
+
+    if err =? catchAsync(await self.sendWantBlock(batch, peer.id)).errorOption:
+      peer.cleanPresence(batch)
+      trace "Error sending batch", err = err.msg
+      return failure(err)
+
+    success()
+
+  pendingBlocks.onAbandon = onAbandonHandler
+  pendingBlocks.onTimeout = onTimeoutHandler
+  pendingBlocks.getPeerForBlock = pendingPeerSelector
+  pendingBlocks.sendBatch = onBatchReadyHandler
 
   if not isNil(network.switch):
     network.switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Joined)

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -279,6 +279,7 @@ proc scheduleBlockSend(
   address: BlockAddress,
   immediate = false,
   delay = DefaultBlockSendRetryDelay,
+  forceDelay = false,
 ) {.gcsafe, raises: [].}
 
 proc failBlockRequest(
@@ -322,6 +323,7 @@ proc scheduleBlockSendTask(
     address: BlockAddress,
     immediate: bool,
     delay = DefaultBlockSendRetryDelay,
+    forceDelay = false,
 ) {.async: (raises: []).} =
   without handle =? self.pendingBlocks.getPendingHandle(address):
     self.pendingBlocks.clearScheduled(address)
@@ -340,7 +342,7 @@ proc scheduleBlockSendTask(
   if not self.pendingBlocks.markScheduled(address):
     return
 
-  if not immediate and not self.pendingBlocks.isFirstAttempt(address):
+  if forceDelay or (not immediate and not self.pendingBlocks.isFirstAttempt(address)):
     let timer = sleepAsync(delay)
     try:
       await handle or timer
@@ -371,8 +373,11 @@ proc scheduleBlockSend(
     address: BlockAddress,
     immediate = false,
     delay = DefaultBlockSendRetryDelay,
+    forceDelay = false,
 ) {.gcsafe, raises: [].} =
-  self.trackedFutures.track(self.scheduleBlockSendTask(address, immediate, delay))
+  self.trackedFutures.track(
+    self.scheduleBlockSendTask(address, immediate, delay, forceDelay)
+  )
 
 proc clearBlockRequestState(
     self: BlockExcEngine, address: BlockAddress
@@ -494,15 +499,9 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
       let address = await next
       trace "Got block from request queue", address
 
-      var shouldRetry = false
-      defer:
-        if shouldRetry:
-          self.pendingBlocks.clearScheduled(address)
-          self.scheduleBlockSend(address)
-
       if address notin self.pendingBlocks or self.pendingBlocks.isRequested(address):
         trace "Address is not pending or already requested", address
-        shouldRetry = true
+        self.pendingBlocks.clearScheduled(address)
         continue
 
       if self.pendingBlocks.retriesExhausted(address):
@@ -519,14 +518,16 @@ proc blockRequestScheduler(self: BlockExcEngine) {.async: (raises: []).} =
 
       if peers.with.len == 0:
         self.searchForNewPeers(address.cidOrTreeCid)
+        self.pendingBlocks.clearScheduled(address)
+        self.scheduleBlockSend(address, forceDelay = true)
         trace "No peer for block, discovery started and retry scheduled", address
-        shouldRetry = true
         continue
 
       let peer = self.selectPeer(peers.with)
       if peer.isNil:
         trace "No peer context, skipping", address
-        shouldRetry = true
+        self.pendingBlocks.clearScheduled(address)
+        self.scheduleBlockSend(address, forceDelay = true)
         continue
 
       var peerBatch: seq[BlockAddress]

--- a/archivist/blockexchange/engine/engine.nim
+++ b/archivist/blockexchange/engine/engine.nim
@@ -362,7 +362,7 @@ proc scheduleTasks(
 proc cancelBlocks(
     self: BlockExcEngine, addrs: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
-  let toCancell = toHashSet(addrs)
+  let toCancel = toHashSet(addrs)
   var scheduledCancellations: Table[PeerId, HashSet[BlockAddress]]
 
   if self.peers.len == 0:
@@ -375,7 +375,7 @@ proc cancelBlocks(
     peerId
 
   for peerCtx in self.peers.peers.values:
-    let intersection = peerCtx.blocksRequested.intersection(toCancell)
+    let intersection = peerCtx.blocksRequested.intersection(toCancel)
     if intersection.len > 0:
       scheduledCancellations[peerCtx.id] = intersection
       peerCtx.cleanPresence(addrs)

--- a/archivist/blockexchange/engine/errors.nim
+++ b/archivist/blockexchange/engine/errors.nim
@@ -18,3 +18,4 @@ type
   StorageFailedEngineError* = object of EngineError
   QueueFailedEngineError* = object of EngineError
   RequestAbandonedEngineError* = object of EngineError
+  NoPeerForBlockError* = object of EngineError

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -48,13 +48,13 @@ declareGauge(
 )
 
 const
-  DefaultMaxBatchBlocks* = 128
-  DefaultMaxBatchBlocksTimeout* = 50.millis
+  DefaultMaxBatchBlocks* = 256
+  DefaultMaxBatchBlocksTimeout* = 1.millis
   DefaultBlockRetries* = 3000
-  DefaultRequestTimeout* = 30.seconds
+  DefaultRequestTimeout* = 10.seconds
   DefaultDiscoveryWaitTimeout = 5.seconds
   DefaultBlockSendRetryDelay* = 500.millis
-  DefaultYieldInterval = 5.millis
+  DefaultYieldInterval = 20.millis
 
 type
   BlockHandle* = Future[BlockDelivery].Raising([CancelledError, EngineError])
@@ -293,10 +293,10 @@ proc addOwner(
       try:
         discard await wrapped
       except CatchableError as exc:
-        warn "Exception monitoring wrapper blockhandle", address, exc = exc.msg
+        trace "Exception monitoring wrapper blockhandle", address, exc = exc.msg
 
       if err =? (await self.releaseWantHandle(wrapped)).errorOption:
-        warn "Unable to release handle", address, err = err.msg
+        trace "Unable to release handle", address, err = err.msg
 
     if priority > pending.priority:
       pending.priority = priority
@@ -376,7 +376,7 @@ proc resolve*(
         archivist_block_exchange_retrieval_time_us.set(retrievalDurationUs)
 
         if retrievalDurationUs > 500000:
-          warn "High block retrieval time", retrievalDurationUs, address = bd.address
+          trace "High block retrieval time", retrievalDurationUs, address = bd.address
       else:
         trace "Block handle already finished", address = bd.address
 
@@ -430,7 +430,7 @@ proc markRequested*(
         await handle or timeoutFut
         let reqPeer = self.getRequestPeerCtx(address).option
         if reqPeer != peer.option:
-          warn "Requested and timed out peers don't match",
+          trace "Requested and timed out peers don't match",
             oldPeer = peer.id, newPeer = reqPeer .? id, address
           return
       except CatchableError as exc:
@@ -503,6 +503,26 @@ proc retryAddresses*(
 
   self.queueWakeEvent.fire()
 
+proc validateBlock(
+    self: PendingBlocksManager, address: BlockAddress
+): Future[bool] {.async: (raises: [CancelledError]).} =
+  without req =? self.blocks .? [address]:
+    trace "Address is not pending", address
+    return false
+
+  if req.state in {Dispatching, InFlight}:
+    trace "Address already in pipeline, skipping", address, state = req.state
+    return false
+
+  if self.retriesExhausted(address):
+    trace "Retries exhausted, skipping block", address
+    await self.failWantHandle(
+      address, RetriesExhaustedEngineError, "Block request retries exhausted"
+    )
+    return false
+
+  return true
+
 proc peerBatchWorker(
     self: PendingBlocksManager, batchReq: BatchReq
 ) {.async: (raises: []).} =
@@ -512,26 +532,6 @@ proc peerBatchWorker(
     if self.running and not batchReq.pipe.empty():
       await self.retryAddresses(batchReq.pipe.toSeq, self.blockSendTimeout)
 
-  proc validateBlock(
-      address: BlockAddress
-  ): Future[bool] {.async: (raises: [CancelledError]).} =
-    without req =? self.blocks .? [address]:
-      trace "Address is not pending", address
-      return false
-
-    if req.state in {Dispatching, InFlight}:
-      trace "Address already in pipeline, skipping", address, state = req.state
-      return false
-
-    if self.retriesExhausted(address):
-      trace "Retries exhausted, skipping block", address
-      await self.failWantHandle(
-        address, RetriesExhaustedEngineError, "Block request retries exhausted"
-      )
-      return false
-
-    return true
-
   try:
     while self.running:
       var batch: seq[BlockAddress] = @[]
@@ -540,7 +540,7 @@ proc peerBatchWorker(
       let first = await batchReq.pipe.get()
       trace "Scheduling peer block", address = first, peer = batchReq.peer.id
 
-      if not await validateBlock(first):
+      if not await self.validateBlock(first):
         trace "Block validation failed", address = first
         continue
 
@@ -551,14 +551,27 @@ proc peerBatchWorker(
         await noCancel batchReq.deadline.cancelAndWait()
 
       while batch.len < self.batchSize:
-        let address =
-          try:
-            await batchReq.pipe.get().wait(batchReq.deadline)
-          except AsyncTimeoutError as exc:
-            trace "Deadline reached", peer = batchReq.peer.id
-            break
+        if batchReq.deadline.finished:
+          trace "Deadline expired", batch = batch.len
+          break
 
-        if not await validateBlock(address):
+        let next = batchReq.pipe.get()
+        try:
+          await next or batchReq.deadline
+        except CatchableError as exc:
+          trace "Exception awaiting queue item", exc = exc.msg
+          if batch.len > 0:
+            await self.retryAddresses(batch, self.blockSendTimeout)
+          raise exc
+        finally:
+          await noCancel next.cancelAndWait()
+
+        if not next.completed:
+          trace "Skipping incomplete queue item"
+          continue
+
+        let address = await next
+        if not await self.validateBlock(address):
           trace "Block validation failed", address
           continue
 
@@ -571,7 +584,7 @@ proc peerBatchWorker(
 
       if not self.sendBatch.isNil and batch.len > 0:
         if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
-          warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
+          warn "Batch send failed", peer = batchReq.peer.id, err = err.msg
           await self.retryAddresses(batch, self.blockSendTimeout)
   except CatchableError as exc:
     trace "Exception in peer batch worker", exc = exc.msg
@@ -622,7 +635,7 @@ proc pushPeerBlock(
           trace "Monitoring peer disconnect", peer = peer.id
           await peer.onDisconnect()
         except CatchableError as exc:
-          warn "Exception in disconnect monitor", exc = exc.msg
+          trace "Exception in disconnect monitor", exc = exc.msg
 
         trace "Peer disconnected, performing cleanup", peer = peer.id
         await noCancel batchReq.workerFut.cancelAndWait()

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -728,6 +728,7 @@ proc start*(self: PendingBlocksManager) {.async: (raises: []).} =
 proc stop*(self: PendingBlocksManager) {.async: (raises: []).} =
   if not self.running:
     trace "Block scheduler not running"
+    return
 
   self.running = false
   self.queueWakeEvent.fire()

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -93,6 +93,7 @@ type
     attempts: int
     generation: int
     addedAt: Moment
+    readyAt: Moment
 
   BlockItem* = object
     address: BlockAddress
@@ -118,6 +119,7 @@ type
     batchSize: int
     batchDeadline: Duration
     discoveryTimeout: Duration
+    blockSendTimeout*: Duration
     retries = DefaultBlockRetries
     running: bool
     trackedFutures: TrackedFutures
@@ -305,7 +307,7 @@ proc addOwner(
     self.blockQueue.push(
       BlockItem(
         address: address,
-        readyAt: now,
+        readyAt: pending.readyAt,
         addedAt: now,
         generation: pending.generation,
         priority: pending.priority,
@@ -330,6 +332,7 @@ proc getWantHandle*(
       startTime: getMonoTime().ticks,
       priority: priority,
       addedAt: now,
+      readyAt: now,
       state: Pending,
     )
     self.lastInclusion = now
@@ -487,10 +490,11 @@ proc retryAddresses*(
 
     req.state = Pending
     req.generation.inc()
+    req.readyAt = Moment.now() + delay
     self.blockQueue.push(
       BlockItem(
         address: address,
-        readyAt: Moment.now() + delay,
+        readyAt: req.readyAt,
         addedAt: req.addedAt,
         generation: req.generation,
         priority: req.priority,
@@ -506,7 +510,7 @@ proc peerBatchWorker(
     # make sure to drain the queue if we're exiting
     # while the engine is still running
     if self.running and not batchReq.pipe.empty():
-      await self.retryAddresses(batchReq.pipe.toSeq, self.discoveryTimeout)
+      await self.retryAddresses(batchReq.pipe.toSeq, self.blockSendTimeout)
 
   proc validateBlock(
       address: BlockAddress
@@ -568,7 +572,7 @@ proc peerBatchWorker(
       if not self.sendBatch.isNil and batch.len > 0:
         if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
           warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
-          await self.retryAddresses(batch, self.discoveryTimeout)
+          await self.retryAddresses(batch, self.blockSendTimeout)
   except CatchableError as exc:
     trace "Exception in peer batch worker", exc = exc.msg
 
@@ -736,6 +740,7 @@ func new*(
     batchSize = DefaultMaxBatchBlocks,
     batchDeadline = DefaultMaxBatchBlocksTimeout,
     discoveryTimeout = DefaultDiscoveryWaitTimeout,
+    blockSendTimeout = DefaultBlockSendRetryDelay,
     yieldInterval = DefaultYieldInterval,
     sendBatch: BatchSendHandler = nil,
     onAbandon: AbandonHandler = nil,
@@ -747,6 +752,7 @@ func new*(
     batchSize: batchSize,
     batchDeadline: batchDeadline,
     discoveryTimeout: discoveryTimeout,
+    blockSendTimeout: blockSendTimeout,
     trackedFutures: TrackedFutures.new(),
     queueWakeEvent: newAsyncEvent(),
     yieldInterval: yieldInterval,

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -7,6 +7,38 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
+## With the introduction of batching, the semantics of shared block handles
+## changed. If two unrelated batches share a subset of handles, and one batch
+## cancels its subset, what should happen to the other handles in the batch?
+##
+## This is a valid condition because of erasure coding: while blocks are being
+## downloaded, erasure recovery might also be running and trying to recover the
+## remaining blocks. Whichever succeeds first will complete or cancel outstanding
+## requests. To prevent these operations from interfering with each other, we use
+## two related mechanisms:
+##
+## - A block handle now has "owners"; the block remains active while
+##   `owners.len > 0`.
+## - Owners are also `BlockHandle` values. This lets callers keep relying on
+##   Future semantics without introducing a separate type that would partially
+##   duplicate those semantics.
+##
+## The outer, owner-facing `BlockHandle` mirrors the underlying `BlockHandle`,
+## which stays active as long as `owners.len > 0` and the block has not been
+## resolved or failed.
+##
+## When an owner/public `BlockHandle` proxy is cancelled, the cancellation does
+## not propagate to the wrapped instance (similar to Chronos' `join` operation).
+## Instead, we unregister that handle from the `owners` set. Once
+## `owners.len == 0`, the underlying future is failed, which also propagates to
+## the proxies. This prevents using it after it has been released or disposed.
+##
+## For callers, the wrappers behave as expected: if more than one code path
+## awaits the `BlockHandle`, cancelling, completing, or failing one wrapper works
+## as expected for that caller, but does not affect handles awaited by other
+## callers.
+##
+
 {.push raises: [].}
 
 import std/tables
@@ -26,6 +58,7 @@ import ../../blocktype
 import ../../logutils
 import ../../utils/futures
 import ../../utils/trackedfutures
+import ../../utils/asyncheapqueue
 
 import ./errors
 
@@ -54,38 +87,17 @@ type
   PendingBlocksTimeoutHandler* =
     proc(address: BlockAddress, peer: PeerId) {.gcsafe, async: (raises: []).}
 
-  ## With the introduction of batching, the semantics of shared block handles
-  ## changed. If two unrelated batches share a subset of handles, and one batch
-  ## cancels its subset, what should happen to the other handles in the batch?
-  ##
-  ## This is a valid condition because of erasure coding: while blocks are being
-  ## downloaded, erasure recovery might also be running and trying to recover the
-  ## remaining blocks. Whichever succeeds first will complete or cancel outstanding
-  ## requests. To prevent these operations from interfering with each other, we use
-  ## two related mechanisms:
-  ##
-  ## - A block handle now has "owners"; the block remains active while
-  ##   `owners.len > 0`.
-  ## - Owners are also `BlockHandle` values. This lets callers keep relying on
-  ##   Future semantics without introducing a separate type that would partially
-  ##   duplicate those semantics.
-  ##
-  ## The outer, owner-facing `BlockHandle` mirrors the underlying `BlockHandle`,
-  ## which stays active as long as `owners.len > 0` and the block has not been
-  ## resolved or failed.
-  ##
-  ## When an owner/public `BlockHandle` proxy is cancelled, the cancellation does
-  ## not propagate to the wrapped instance (similar to Chronos' `join` operation).
-  ## Instead, we unregister that handle from the `owners` set. Once
-  ## `owners.len == 0`, the underlying future is failed, which also propagates to
-  ## the proxies. This prevents using it after it has been released or disposed.
-  ##
-  ## For callers, the wrappers behave as expected: if more than one code path
-  ## awaits the `BlockHandle`, cancelling, completing, or failing one wrapper works
-  ## as expected for that caller, but does not affect handles awaited by other
-  ## callers.
-  ##
-  BlockReq = ref object
+  SchedulableReq* = ref object of RootObj
+    address*: BlockAddress
+    priority*: int
+    insertedAt: Moment
+    eligibleAt: Moment
+    queued: bool
+    attempts: int
+    discoveryWaiting: bool
+    discoveryDeadline: Moment
+
+  BlockReq* = ref object of SchedulableReq
     handle: BlockHandle
     owners: HashSet[BlockHandle]
     requested: ?PeerId
@@ -103,9 +115,17 @@ type
     onAbandon*: PendingBlocksAbandonHandler
     onTimeout*: PendingBlocksTimeoutHandler
     handleMonitors: TrackedFutures
+    readyQueue*: AsyncHeapQueue[SchedulableReq]
+    delayedTimer: Future[void]
+    earliestDelay: Moment
 
 func hash*(handle: BlockHandle): Hash =
   cast[pointer](handle).hash
+
+proc `<`*(a, b: SchedulableReq): bool =
+  if a.priority != b.priority:
+    return a.priority < b.priority
+  a.insertedAt < b.insertedAt
 
 proc updatePendingBlockGauge(p: PendingBlocksManager) =
   archivist_block_exchange_pending_block_requests.set(p.blocks.len.int64)
@@ -147,10 +167,12 @@ proc getWantHandle*(
   if address notin self.blocks:
     let handle = BlockHandle.init("pendingBlocks.sharedHandle")
     self.blocks[address] = BlockReq(
+      address: address,
       handle: handle,
       requested: requested,
       blockRetries: self.blockRetries,
       startTime: getMonoTime().ticks,
+      insertedAt: Moment.now(),
     )
     self.lastInclusion = Moment.now()
     self.updatePendingBlockGauge()
@@ -294,16 +316,6 @@ func isScheduled*(self: PendingBlocksManager, address: BlockAddress): bool =
     return pending.scheduled
   false
 
-func markScheduled*(self: PendingBlocksManager, address: BlockAddress): bool =
-  if var pending =? self.blocks .? [address]:
-    if pending.requested.isSome or pending.scheduled:
-      return false
-
-    pending.scheduled = true
-    return true
-
-  false
-
 func clearScheduled*(self: PendingBlocksManager, address: BlockAddress) =
   if var pending =? self.blocks .? [address]:
     pending.scheduled = false
@@ -433,7 +445,78 @@ proc wantListLen*(self: PendingBlocksManager): int =
 func len*(self: PendingBlocksManager): int =
   self.blocks.len
 
+proc enqueue*(
+    self: PendingBlocksManager, address: BlockAddress, priority: int
+): Future[void] {.async: (raises: [CancelledError]).} =
+  without req =? self.blocks .? [address]:
+    return
+
+  if req.handle.finished or req.requested.isSome or req.queued or req.scheduled or
+      req.discoveryWaiting or req.eligibleAt > Moment.now():
+    return
+
+  req.priority = priority
+  req.scheduled = true
+  req.queued = true
+  req.insertedAt = Moment.now()
+  await self.readyQueue.push(req)
+
+proc dequeue*(
+    self: PendingBlocksManager
+): Future[BlockAddress] {.async: (raises: [CancelledError]).} =
+  while true:
+    let req = await self.readyQueue.pop()
+    req.queued = false
+
+    if current =? self.blocks .? [req.address]:
+      if current == BlockReq(req):
+        return req.address
+
+func isQueued*(self: PendingBlocksManager, address: BlockAddress): bool =
+  if req =? self.blocks .? [address]:
+    return req.queued
+  false
+
+proc isEligible*(self: PendingBlocksManager, address: BlockAddress): bool =
+  if req =? self.blocks .? [address]:
+    return req.eligibleAt <= Moment.now()
+  false
+
+proc setEligibleAt*(
+    self: PendingBlocksManager, address: BlockAddress, deadline: Moment
+) =
+  if req =? self.blocks .? [address]:
+    req.eligibleAt = deadline
+    req.scheduled = false
+
+proc markDispatched*(self: PendingBlocksManager, address: BlockAddress) =
+  if req =? self.blocks .? [address]:
+    req.scheduled = false
+
+proc enterDiscoveryWait*(
+    self: PendingBlocksManager, address: BlockAddress, deadline: Moment
+) =
+  if req =? self.blocks .? [address]:
+    req.discoveryWaiting = true
+    req.discoveryDeadline = deadline
+    req.scheduled = false
+
+proc wakeOnPresence*(self: PendingBlocksManager, address: BlockAddress) =
+  if req =? self.blocks .? [address]:
+    req.discoveryWaiting = false
+    if not req.queued and not req.requested.isSome and req.eligibleAt <= Moment.now():
+      req.queued = true
+      req.scheduled = true
+      if err =? self.readyQueue.pushNoWait(req).errorOption:
+        req.queued = false
+        req.scheduled = false
+        trace "Ready queue full, cannot wake", address, err = $err
+
 func new*(
     T: type PendingBlocksManager, retries = DefaultBlockRetries
 ): PendingBlocksManager =
-  PendingBlocksManager(blockRetries: retries, handleMonitors: TrackedFutures.new())
+  PendingBlocksManager(
+    blockRetries: retries,
+    handleMonitors: TrackedFutures.new(),
+    readyQueue: newAsyncHeapQueue[SchedulableReq](),
+  )

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -482,11 +482,16 @@ proc isEligible*(self: PendingBlocksManager, address: BlockAddress): bool =
     return req.eligibleAt <= Moment.now()
   false
 
+func isDiscoveryWaiting*(self: PendingBlocksManager, address: BlockAddress): bool =
+  if req =? self.blocks .? [address]:
+    return req.discoveryWaiting
+  false
+
 proc setEligibleAt*(
-    self: PendingBlocksManager, address: BlockAddress, deadline: Moment
+    self: PendingBlocksManager, address: BlockAddress, deadline: Duration
 ) =
   if req =? self.blocks .? [address]:
-    req.eligibleAt = deadline
+    req.eligibleAt = Moment.now() + deadline
     req.scheduled = false
 
 proc markDispatched*(self: PendingBlocksManager, address: BlockAddress) =
@@ -494,11 +499,11 @@ proc markDispatched*(self: PendingBlocksManager, address: BlockAddress) =
     req.scheduled = false
 
 proc enterDiscoveryWait*(
-    self: PendingBlocksManager, address: BlockAddress, deadline: Moment
+    self: PendingBlocksManager, address: BlockAddress, deadline: Duration
 ) =
   if req =? self.blocks .? [address]:
     req.discoveryWaiting = true
-    req.discoveryDeadline = deadline
+    req.discoveryDeadline = Moment.now() + deadline
     req.scheduled = false
 
 proc wakeOnPresence*(self: PendingBlocksManager, address: BlockAddress) =

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -132,7 +132,7 @@ func `<`(a, b: BlockItem): bool =
   if a.readyAt != b.readyAt:
     return a.readyAt < b.readyAt
   if a.priority != b.priority:
-    return a.priority < b.priority
+    return a.priority > b.priority # higher numeric = higher priority
   a.addedAt < b.addedAt
 
 proc updatePendingBlockGauge(p: PendingBlocksManager) =

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -2,48 +2,17 @@
 ## Copyright (c) 2021 Status Research & Development GmbH
 ## Licensed under either of
 ##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
-##  * MIT license, ([LICENSE-MIT](LICENSE-MIT))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
 ## at your option.
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
-
-## With the introduction of batching, the semantics of shared block handles
-## changed. If two unrelated batches share a subset of handles, and one batch
-## cancels its subset, what should happen to the other handles in the batch?
-##
-## This is a valid condition because of erasure coding: while blocks are being
-## downloaded, erasure recovery might also be running and trying to recover the
-## remaining blocks. Whichever succeeds first will complete or cancel outstanding
-## requests. To prevent these operations from interfering with each other, we use
-## two related mechanisms:
-##
-## - A block handle now has "owners"; the block remains active while
-##   `owners.len > 0`.
-## - Owners are also `BlockHandle` values. This lets callers keep relying on
-##   Future semantics without introducing a separate type that would partially
-##   duplicate those semantics.
-##
-## The outer, owner-facing `BlockHandle` mirrors the underlying `BlockHandle`,
-## which stays active as long as `owners.len > 0` and the block has not been
-## resolved or failed.
-##
-## When an owner/public `BlockHandle` proxy is cancelled, the cancellation does
-## not propagate to the wrapped instance (similar to Chronos' `join` operation).
-## Instead, we unregister that handle from the `owners` set. Once
-## `owners.len == 0`, the underlying future is failed, which also propagates to
-## the proxies. This prevents using it after it has been released or disposed.
-##
-## For callers, the wrappers behave as expected: if more than one code path
-## awaits the `BlockHandle`, cancelling, completing, or failing one wrapper works
-## as expected for that caller, but does not affect handles awaited by other
-## callers.
-##
 
 {.push raises: [].}
 
 import std/tables
 import std/monotimes
 import std/hashes
+import std/heapqueue
 import std/sequtils
 import std/sets
 import std/strformat
@@ -52,13 +21,15 @@ import pkg/chronos
 import pkg/libp2p
 import pkg/questionable
 import pkg/metrics
+import pkg/results
 
 import ../protobuf/blockexc
+import ../peers/peerctxstore
+import ../peers/peercontext
 import ../../blocktype
 import ../../logutils
 import ../../utils/futures
 import ../../utils/trackedfutures
-import ../../utils/asyncheapqueue
 
 import ./errors
 
@@ -77,216 +48,94 @@ declareGauge(
 )
 
 const
+  DefaultMaxBatchBlocks* = 128
+  DefaultMaxBatchBlocksTimeout* = 50.millis
   DefaultBlockRetries* = 3000
   DefaultRequestTimeout* = 30.seconds
+  DefaultDiscoveryWaitTimeout = 5.seconds
+  DefaultBlockSendRetryDelay* = 500.millis
 
 type
   BlockHandle* = Future[BlockDelivery].Raising([CancelledError, EngineError])
-  PendingBlocksAbandonHandler* =
-    proc(address: BlockAddress) {.gcsafe, async: (raises: []).}
-  PendingBlocksTimeoutHandler* =
-    proc(address: BlockAddress, peer: PeerId) {.gcsafe, async: (raises: []).}
 
-  SchedulableReq* = ref object of RootObj
-    address*: BlockAddress
-    priority*: int
-    insertedAt: Moment
-    eligibleAt: Moment
-    queued: bool
-    attempts: int
-    discoveryWaiting: bool
-    discoveryDeadline: Moment
+  AbandonHandler* =
+    proc(address: BlockAddress) {.gcsafe, async: (raises: [CancelledError]).}
 
-  BlockReq* = ref object of SchedulableReq
+  TimeoutHandler* = proc(address: BlockAddress, peer: PeerId) {.
+    gcsafe, async: (raises: [CancelledError])
+  .}
+
+  BatchSendHandler* = proc(
+    peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+  ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).}
+
+  PeerSelectorHandler* = proc(address: BlockAddress): Future[?!BlockExcPeerCtx] {.
+    gcsafe, async: (raises: [CancelledError])
+  .}
+
+  BlockReqState = enum
+    Pending
+    Dispatching
+    Scheduled
+    InFlight
+
+  BlockReq = ref object
     handle: BlockHandle
+    address: BlockAddress
     owners: HashSet[BlockHandle]
-    requested: ?PeerId
+    state: BlockReqState
+    requestedPeer: BlockExcPeerCtx # nil = unassigned
     requestTimeout: Future[void]
-    scheduled: bool
     startTime: int64
-    blockRetries: int
+    priority: int
+    retries: int
+    attempts: int
+    generation: int
+    addedAt: Moment
+
+  BlockItem* = object
+    address: BlockAddress
+    readyAt: Moment
+    addedAt: Moment
+    generation: int
+    priority: int
+
+  BatchReq = object
+    peer: BlockExcPeerCtx
+    deadline: Future[void]
+    pipe: AsyncQueue[BlockAddress]
 
   PendingBlocksManager* = ref object of RootObj
-    blockRetries*: int = DefaultBlockRetries
-    blocks: Table[BlockAddress, BlockReq] # pending Block requests
-    # the map between pending request and owned handles
+    blocks: Table[BlockAddress, BlockReq]
     handles: Table[BlockHandle, BlockAddress]
+    blockQueue: HeapQueue[BlockItem]
+    byPeer: Table[PeerId, BatchReq]
+    queueWakeEvent: AsyncEvent
     lastInclusion*: Moment
-    onAbandon*: PendingBlocksAbandonHandler
-    onTimeout*: PendingBlocksTimeoutHandler
-    handleMonitors: TrackedFutures
-    readyQueue*: AsyncHeapQueue[SchedulableReq]
-    delayedTimer: Future[void]
-    earliestDelay: Moment
+    batchSize: int
+    batchDeadline: Duration
+    discoveryTimeout: Duration
+    retries = DefaultBlockRetries
+    running: bool
+    trackedFutures: TrackedFutures
 
-func hash*(handle: BlockHandle): Hash =
+    onAbandon*: AbandonHandler
+    onTimeout*: TimeoutHandler
+    sendBatch*: BatchSendHandler
+    getPeerForBlock*: PeerSelectorHandler
+
+func hash(handle: BlockHandle): Hash =
   cast[pointer](handle).hash
 
-proc `<`*(a, b: SchedulableReq): bool =
+func `<`(a, b: BlockItem): bool =
+  if a.readyAt != b.readyAt:
+    return a.readyAt < b.readyAt
   if a.priority != b.priority:
     return a.priority < b.priority
-  a.insertedAt < b.insertedAt
+  a.addedAt < b.addedAt
 
 proc updatePendingBlockGauge(p: PendingBlocksManager) =
   archivist_block_exchange_pending_block_requests.set(p.blocks.len.int64)
-
-proc releaseWantHandle(
-  self: PendingBlocksManager, wrapped: BlockHandle
-): Future[?!void] {.async: (raises: []), gcsafe.}
-
-proc addOwner(
-    self: PendingBlocksManager, address: BlockAddress
-): BlockHandle {.gcsafe.} =
-  if var pending =? self.blocks .? [address]:
-    let wrapped = pending.handle.wrap()
-
-    pending.owners.incl(wrapped)
-    self.handles[wrapped] = address
-
-    proc wrappedMonitor(): Future[void] {.gcsafe, async: (raises: []).} =
-      try:
-        discard await wrapped # discard block delivery
-      except CatchableError as exc:
-        warn "Exception monitoring wrapper blockhande", address, exc = exc.msg
-
-      if err =? (await self.releaseWantHandle(wrapped)).errorOption:
-        warn "Unable to release handle", address, err = err.msg
-
-    self.handleMonitors.track(wrappedMonitor())
-
-    return wrapped
-
-  raiseAssert "Pending block missing while adding owner"
-
-proc getWantHandle*(
-    self: PendingBlocksManager, address: BlockAddress, requested: ?PeerId = PeerId.none
-): BlockHandle =
-  ## Add an event for a block
-  ##
-
-  if address notin self.blocks:
-    let handle = BlockHandle.init("pendingBlocks.sharedHandle")
-    self.blocks[address] = BlockReq(
-      address: address,
-      handle: handle,
-      requested: requested,
-      blockRetries: self.blockRetries,
-      startTime: getMonoTime().ticks,
-      insertedAt: Moment.now(),
-    )
-    self.lastInclusion = Moment.now()
-    self.updatePendingBlockGauge()
-
-    proc handleMonitor() {.async: (raises: []).} =
-      try:
-        discard await handle
-      except CatchableError as exc:
-        trace "Exception in handle monitor", exc = exc.msg
-
-      if var req =? self.blocks .? [address]:
-        var timeoutFut: Future[void]
-        if not req.requestTimeout.isNil:
-          timeoutFut = req.requestTimeout
-          req.requestTimeout = nil
-          await noCancel timeoutFut.cancelAndWait()
-          req.requested = PeerId.none
-
-      self.blocks.del(address)
-      self.updatePendingBlockGauge()
-
-    self.handleMonitors.track(handleMonitor())
-
-  return self.addOwner(address)
-
-proc getWantHandle*(
-    self: PendingBlocksManager, cid: Cid, requested = PeerId.none
-): BlockHandle =
-  self.getWantHandle(BlockAddress.init(cid), requested)
-
-proc releaseWantHandle(
-    self: PendingBlocksManager, wrapped: BlockHandle
-): Future[?!void] {.async: (raises: []), gcsafe.} =
-  if address =? self.handles .? [wrapped]:
-    self.handles.del(wrapped)
-    if var req =? self.blocks .? [address]:
-      req.owners.excl(wrapped)
-      if req.owners.len == 0:
-        if not req.handle.finished:
-          warn "Abandoning block", address
-          req.handle.fail(
-            newException(RequestAbandonedEngineError, fmt"Abandoning block {address}")
-          )
-
-          if not self.onAbandon.isNil:
-            trace "Handle abandoned, running on abandon hook", address
-            await noCancel self.onAbandon(address)
-
-      return success()
-
-  failure("Unable to find block handle")
-
-proc resolve*(self: PendingBlocksManager, blocksDelivery: seq[BlockDelivery]) =
-  ## Resolve pending blocks
-  ##
-
-  for bd in blocksDelivery:
-    if blockReq =? self.blocks .? [bd.address]:
-      if not blockReq.handle.finished:
-        trace "Resolving pending block", address = bd.address
-        let
-          startTime = blockReq.startTime
-          stopTime = getMonoTime().ticks
-          retrievalDurationUs = (stopTime - startTime) div 1000
-
-        blockReq.handle.complete(bd)
-
-        archivist_block_exchange_retrieval_time_us.set(retrievalDurationUs)
-
-        if retrievalDurationUs > 500000:
-          warn "High block retrieval time", retrievalDurationUs, address = bd.address
-      else:
-        trace "Block handle already finished", address = bd.address
-
-proc resolve*(self: PendingBlocksManager, address: BlockAddress, blk: Block) =
-  self.resolve(@[BlockDelivery(blk: blk, address: address)])
-
-proc failOwners(
-    self: PendingBlocksManager, address: BlockAddress, err: ref EngineError
-) {.gcsafe.} =
-  if req =? self.blocks .? [address]:
-    for wrapped in req.owners:
-      if not wrapped.finished:
-        wrapped.fail(err)
-
-proc failWantHandle*(
-    self: PendingBlocksManager,
-    address: BlockAddress,
-    errType: typedesc[EngineError],
-    msg: string,
-) =
-  if blockReq =? self.blocks .? [address]:
-    if not blockReq.handle.finished:
-      let err = (ref errType)(address: address, msg: msg)
-      blockReq.handle.fail(err)
-      self.failOwners(address, err)
-
-proc cancelAll*(self: PendingBlocksManager): Future[void] {.async: (raises: []).} =
-  ## Cancel all outstanding block handles and other futures
-  ##
-
-  var handles: seq[BlockHandle]
-  for req in self.blocks.mvalues:
-    handles.add(req.handle)
-    for owner in req.owners:
-      handles.add(owner)
-
-  let cancellations = handles.mapIt(it.cancelAndWait())
-
-  self.handles.clear()
-  self.blocks.clear()
-  self.updatePendingBlockGauge()
-
-  await noCancel allFutures(cancellations & @[self.handleMonitors.cancelTracked])
 
 func owners*(self: PendingBlocksManager, address: BlockAddress): int =
   if pending =? self.blocks .? [address]: pending.owners.len else: 0
@@ -295,39 +144,45 @@ func owners*(self: PendingBlocksManager, cid: Cid): int =
   self.owners(BlockAddress.init(cid))
 
 func retries*(self: PendingBlocksManager, address: BlockAddress): int =
-  if pending =? self.blocks .? [address]: pending.blockRetries else: 0
+  if pending =? self.blocks .? [address]: pending.retries else: 0
 
 func decRetries*(self: PendingBlocksManager, address: BlockAddress) =
   if var pending =? self.blocks .? [address]:
-    pending.blockRetries -= 1
+    pending.retries -= 1
 
 func retriesExhausted*(self: PendingBlocksManager, address: BlockAddress): bool =
   if pending =? self.blocks .? [address]:
-    return pending.blockRetries <= 0
+    return pending.retries <= 0
   false
 
 func isRequested*(self: PendingBlocksManager, address: BlockAddress): bool =
   if pending =? self.blocks .? [address]:
-    return pending.requested.isSome
+    return pending.requestedPeer != nil
   false
-
-func isScheduled*(self: PendingBlocksManager, address: BlockAddress): bool =
-  if pending =? self.blocks .? [address]:
-    return pending.scheduled
-  false
-
-func clearScheduled*(self: PendingBlocksManager, address: BlockAddress) =
-  if var pending =? self.blocks .? [address]:
-    pending.scheduled = false
 
 func isFirstAttempt*(self: PendingBlocksManager, address: BlockAddress): bool =
   if pending =? self.blocks .? [address]:
-    return pending.blockRetries == self.blockRetries
+    return pending.retries == self.retries
   false
 
-func getRequestPeer*(self: PendingBlocksManager, address: BlockAddress): ?PeerId =
+func getRequestPeerCtx*(
+    self: PendingBlocksManager, address: BlockAddress
+): BlockExcPeerCtx =
   if pending =? self.blocks .? [address]:
-    return pending.requested
+    return pending.requestedPeer
+  nil
+
+func getRequestPeerCtx*(
+    self: PendingBlocksManager, handle: BlockHandle
+): BlockExcPeerCtx =
+  if address =? self.handles .? [handle]:
+    return self.getRequestPeerCtx(address)
+  nil
+
+func getRequestPeer*(self: PendingBlocksManager, address: BlockAddress): ?PeerId =
+  let peer = self.getRequestPeerCtx(address)
+  if peer != nil:
+    return peer.id.some
   PeerId.none
 
 func getRequestPeer*(self: PendingBlocksManager, handle: BlockHandle): ?PeerId =
@@ -339,82 +194,6 @@ func getHandleAddress*(self: PendingBlocksManager, handle: BlockHandle): ?BlockA
   if address =? self.handles .? [handle]:
     return address.some
   return BlockAddress.none
-
-func getPendingHandle*(
-    self: PendingBlocksManager, address: BlockAddress
-): ?BlockHandle =
-  if req =? self.blocks .? [address]:
-    return req.handle.some
-  return BlockHandle.none
-
-proc markRequested*(
-    self: PendingBlocksManager,
-    address: BlockAddress,
-    peer: PeerId,
-    timeout: Duration = DefaultRequestTimeout,
-): ?PeerId =
-  let requestedPeer = self.getRequestPeer(address)
-  if requestedPeer.isSome:
-    trace "Block already requested", address, requestedPeer
-    return requestedPeer
-
-  if var pending =? self.blocks .? [address]:
-    pending.requested = peer.some
-
-    let handle = pending.handle
-    var currentMonitor: Future[void]
-    proc timeoutMonitor() {.async: (raises: []).} =
-      let timeoutFut = sleepAsync(timeout)
-      try:
-        await handle or timeoutFut
-        let requestedPeer = self.getRequestPeer(address)
-        if requestedPeer != peer.some:
-          warn "Requested and timed out peers don't match, request might have completed!",
-            oldPeer = peer, newPeer = requestedPeer, address
-          return
-      except CatchableError as exc:
-        trace "Exception in request timeout monitor", exc = exc.msg
-      finally:
-        await noCancel timeoutFut.cancelAndWait()
-
-      if handle.finished:
-        trace "Exiting timeout monitor, handle finished", address, peer
-        return
-
-      if var req =? self.blocks .? [address]:
-        if req.requestTimeout == currentMonitor:
-          req.requestTimeout = nil
-
-        if req.requested == peer.some:
-          req.requested = PeerId.none
-
-      if timeoutFut.completed:
-        if not self.onTimeout.isNil:
-          trace "Timeout elapsed, calling onTimeout callback", peer, address
-          await noCancel self.onTimeout(address, peer)
-
-    currentMonitor = timeoutMonitor()
-    pending.requestTimeout = currentMonitor
-    pending.scheduled = false
-
-    return pending.requested
-
-proc clearRequest*(
-    self: PendingBlocksManager, address: BlockAddress
-) {.async: (raises: []).} =
-  if var req =? self.blocks .? [address]:
-    if not req.requestTimeout.isNil:
-      let reqTimeoutFut = req.requestTimeout
-      req.requestTimeout = nil
-      trace "Cancelling block request", address
-      await noCancel reqTimeoutFut.cancelAndWait()
-
-proc clearRequest*(
-    self: PendingBlocksManager, address: BlockAddress, peer: PeerId
-) {.async: (raises: []).} =
-  if req =? self.blocks .? [address]:
-    if req.requested == peer.some:
-      await self.clearRequest(address)
 
 func contains*(self: PendingBlocksManager, cid: Cid): bool =
   BlockAddress.init(cid) in self.blocks
@@ -445,83 +224,491 @@ proc wantListLen*(self: PendingBlocksManager): int =
 func len*(self: PendingBlocksManager): int =
   self.blocks.len
 
-proc enqueue*(
-    self: PendingBlocksManager, address: BlockAddress, priority: int
-): Future[void] {.async: (raises: [CancelledError]).} =
-  without req =? self.blocks .? [address]:
+proc retryAddresses*(
+    self: PendingBlocksManager,
+    addresses: seq[BlockAddress],
+    delay: Duration = DefaultDiscoveryWaitTimeout,
+) {.async: (raises: []).}
+
+proc clearPeerAssignment(
+    self: PendingBlocksManager, address: BlockAddress
+) {.async: (raises: []).} =
+  if var req =? self.blocks .? [address]:
+    let
+      timeoutFut = req.requestTimeout
+      assignedPeer = req.requestedPeer
+
+    # Detach synchronously -- no other async task can observe stale state
+    req.requestTimeout = nil
+    req.requestedPeer = nil
+    if assignedPeer != nil:
+      assignedPeer.blockRequestCleared(address)
+
+    # Now safely cancel the timeout monitor
+    if timeoutFut != nil:
+      await noCancel timeoutFut.cancelAndWait()
+
+proc releaseWantHandle(
+    self: PendingBlocksManager, wrapped: BlockHandle
+): Future[?!void] {.async: (raises: []), gcsafe.} =
+  if address =? self.handles .? [wrapped]:
+    self.handles.del(wrapped)
+    if var req =? self.blocks .? [address]:
+      req.owners.excl(wrapped)
+      if req.owners.len == 0:
+        if not req.handle.finished:
+          warn "Abandoning block", address
+          await self.clearPeerAssignment(address)
+          req.handle.fail(
+            newException(RequestAbandonedEngineError, fmt"Abandoning block {address}")
+          )
+
+          if not self.onAbandon.isNil:
+            trace "Handle abandoned, running on abandon hook", address
+            await noCancel self.onAbandon(address)
+
+      self.queueWakeEvent.fire()
+      return success()
+
+  failure("Unable to find block handle")
+
+proc addOwner(
+    self: PendingBlocksManager, address: BlockAddress, priority = 0
+): BlockHandle {.gcsafe.} =
+  if var pending =? self.blocks .? [address]:
+    let wrapped = pending.handle.wrap()
+
+    pending.owners.incl(wrapped)
+    self.handles[wrapped] = address
+
+    proc wrappedMonitor(): Future[void] {.gcsafe, async: (raises: []).} =
+      try:
+        discard await wrapped
+      except CatchableError as exc:
+        warn "Exception monitoring wrapper blockhandle", address, exc = exc.msg
+
+      if err =? (await self.releaseWantHandle(wrapped)).errorOption:
+        warn "Unable to release handle", address, err = err.msg
+
+    if priority > pending.priority:
+      pending.priority = priority
+
+    self.trackedFutures.track(wrappedMonitor())
+    pending.generation.inc()
+    let now = Moment.now()
+    self.blockQueue.push(
+      BlockItem(
+        address: address,
+        readyAt: now,
+        addedAt: now,
+        generation: pending.generation,
+        priority: pending.priority,
+      )
+    )
+
+    self.queueWakeEvent.fire()
+    return wrapped
+
+  raiseAssert "Pending block missing while adding owner"
+
+proc getWantHandle*(
+    self: PendingBlocksManager, address: BlockAddress, priority = 0
+): BlockHandle =
+  if address notin self.blocks:
+    let handle = BlockHandle.init("pendingBlocks.sharedHandle")
+    let now = Moment.now()
+    self.blocks[address] = BlockReq(
+      address: address,
+      handle: handle,
+      retries: self.retries,
+      startTime: getMonoTime().ticks,
+      priority: priority,
+      addedAt: now,
+      state: Pending,
+    )
+    self.lastInclusion = now
+    self.updatePendingBlockGauge()
+
+    proc handleMonitor() {.async: (raises: []).} =
+      try:
+        discard await handle
+      except CatchableError as exc:
+        trace "Exception in handle monitor", exc = exc.msg
+
+      if var req =? self.blocks .? [address]:
+        await self.clearPeerAssignment(address)
+
+      self.blocks.del(address)
+      self.updatePendingBlockGauge()
+
+    self.trackedFutures.track(handleMonitor())
+
+  return self.addOwner(address, priority)
+
+proc getWantHandle*(self: PendingBlocksManager, cid: Cid): BlockHandle =
+  self.getWantHandle(BlockAddress.init(cid))
+
+proc resolve*(
+    self: PendingBlocksManager, blocksDelivery: seq[BlockDelivery]
+) {.async: (raises: [CancelledError]).} =
+  for bd in blocksDelivery:
+    if blockReq =? self.blocks .? [bd.address]:
+      if not blockReq.handle.finished:
+        trace "Resolving pending block", address = bd.address
+        let
+          startTime = blockReq.startTime
+          stopTime = getMonoTime().ticks
+          retrievalDurationUs = (stopTime - startTime) div 1000
+
+        await self.clearPeerAssignment(bd.address)
+        if not blockReq.handle.finished:
+          blockReq.handle.complete(bd)
+
+        archivist_block_exchange_retrieval_time_us.set(retrievalDurationUs)
+
+        if retrievalDurationUs > 500000:
+          warn "High block retrieval time", retrievalDurationUs, address = bd.address
+      else:
+        trace "Block handle already finished", address = bd.address
+
+proc resolve*(
+    self: PendingBlocksManager, address: BlockAddress, blk: Block
+) {.async: (raises: [CancelledError]).} =
+  await self.resolve(@[BlockDelivery(blk: blk, address: address)])
+
+proc failOwners(
+    self: PendingBlocksManager, address: BlockAddress, err: ref EngineError
+) {.gcsafe.} =
+  if req =? self.blocks .? [address]:
+    for wrapped in req.owners:
+      if not wrapped.finished:
+        wrapped.fail(err)
+
+proc failWantHandle*(
+    self: PendingBlocksManager,
+    address: BlockAddress,
+    errType: typedesc[EngineError],
+    msg: string,
+) {.async: (raises: []).} =
+  if blockReq =? self.blocks .? [address]:
+    if not blockReq.handle.finished:
+      await self.clearPeerAssignment(address)
+      let err = (ref errType)(address: address, msg: msg)
+      blockReq.handle.fail(err)
+      self.failOwners(address, err)
+
+proc markRequested*(
+    self: PendingBlocksManager,
+    address: BlockAddress,
+    peer: BlockExcPeerCtx,
+    timeout: Duration = DefaultRequestTimeout,
+): BlockExcPeerCtx =
+  let prevPeer = self.getRequestPeerCtx(address)
+  if prevPeer != nil:
+    trace "Block already requested", address, requestedPeer = prevPeer.id
+    return prevPeer
+
+  if var pending =? self.blocks .? [address]:
+    pending.requestedPeer = peer
+    pending.state = InFlight
+    pending.retries -= 1
+    peer.blockRequestScheduled(address)
+
+    let handle = pending.handle
+    var currentMonitor: Future[void].Raising([])
+    proc timeoutMonitor() {.async: (raises: []).} =
+      let timeoutFut = sleepAsync(timeout)
+      try:
+        await handle or timeoutFut
+        let reqPeer = self.getRequestPeerCtx(address).option
+        if reqPeer != peer.option:
+          warn "Requested and timed out peers don't match",
+            oldPeer = peer.id, newPeer = reqPeer .? id, address
+          return
+      except CatchableError as exc:
+        trace "Exception in request timeout monitor", exc = exc.msg
+      finally:
+        await noCancel timeoutFut.cancelAndWait()
+
+      if handle.finished:
+        trace "Exiting timeout monitor, handle finished", address, peer = peer.id
+        return
+
+      if var req =? self.blocks .? [address]:
+        if req.requestTimeout == currentMonitor:
+          req.requestTimeout = nil
+
+      if timeoutFut.completed:
+        # Requeue the block for retry before notifying the engine.
+        # Only if we still own the assignment (no concurrent clear/resolve).
+        if var req =? self.blocks .? [address]:
+          if req.requestTimeout == currentMonitor and req.requestedPeer == peer:
+            req.requestedPeer.blockRequestCleared(address)
+            req.requestedPeer = nil
+            req.requestTimeout = nil
+            await self.retryAddresses(@[address], 0.millis)
+
+        if not self.onTimeout.isNil:
+          trace "Timeout elapsed, calling onTimeout callback", peer = peer.id, address
+          await noCancel self.onTimeout(address, peer.id)
+
+    currentMonitor = timeoutMonitor()
+    pending.requestTimeout = currentMonitor
+    self.trackedFutures.track(currentMonitor)
+
+    return pending.requestedPeer
+
+proc clearRequest*(
+    self: PendingBlocksManager, address: BlockAddress
+) {.async: (raises: []).} =
+  await self.clearPeerAssignment(address)
+
+proc clearRequest*(
+    self: PendingBlocksManager, address: BlockAddress, peer: BlockExcPeerCtx
+) {.async: (raises: []).} =
+  if req =? self.blocks .? [address]:
+    if req.requestedPeer == peer:
+      await self.clearPeerAssignment(address)
+
+proc retryAddresses*(
+    self: PendingBlocksManager,
+    addresses: seq[BlockAddress],
+    delay: Duration = DefaultDiscoveryWaitTimeout,
+) {.async: (raises: []).} =
+  for address in addresses:
+    without req =? self.blocks .? [address]:
+      continue
+
+    if req.state == Dispatching:
+      continue
+
+    await self.clearPeerAssignment(address)
+
+    req.state = Pending
+    req.generation.inc()
+    self.blockQueue.push(
+      BlockItem(
+        address: address,
+        readyAt: Moment.now() + delay,
+        addedAt: req.addedAt,
+        generation: req.generation,
+        priority: req.priority,
+      )
+    )
+
+  self.queueWakeEvent.fire()
+
+proc peerBatchWorker(
+    self: PendingBlocksManager, batchReq: sink BatchReq
+) {.async: (raises: []).} =
+  try:
+    while self.running:
+      var batch: seq[BlockAddress] = @[await batchReq.pipe.get()]
+
+      batchReq.deadline = sleepAsync(self.batchDeadline)
+      defer:
+        await noCancel batchReq.deadline.cancelAndWait()
+
+      while batch.len < self.batchSize:
+        let address =
+          try:
+            await batchReq.pipe.get().wait(batchReq.deadline)
+          except AsyncTimeoutError as exc:
+            trace "Deadline reached", peer = batchReq.peer.id
+            break
+
+        without req =? self.blocks .? [address]:
+          trace "Address is not pending", address
+          continue
+
+        if req.state in {Dispatching, InFlight}:
+          trace "Address already in pipeline, skipping", address, state = req.state
+          continue
+
+        if self.retriesExhausted(address):
+          trace "Retries exhausted, skipping block", address
+          await self.failWantHandle(
+            address, RetriesExhaustedEngineError, "Block request retries exhausted"
+          )
+          continue
+
+        batch.add(address)
+
+      trace "Dispatching batch to peer", peer = batchReq.peer.id, batch = batch.len
+
+      # Mark all as in-flight BEFORE calling engine
+      for address in batch:
+        discard self.markRequested(address, batchReq.peer)
+
+      if not self.sendBatch.isNil and batch.len > 0:
+        if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
+          warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
+          var toRetry: seq[BlockAddress]
+          for address in batch:
+            if req =? self.blocks .? [address]:
+              if req.requestedPeer == batchReq.peer:
+                toRetry.add(address)
+          if toRetry.len > 0:
+            await self.retryAddresses(toRetry)
+  except CatchableError as exc:
+    trace "Exception in peer batch worker", exc = exc.msg
+
+proc pushPeerBlock(
+    self: PendingBlocksManager, address: BlockAddress
+) {.async: (raises: []).} =
+  try:
+    without req =? self.blocks .? [address]:
+      trace "Address not in blocks", address
+      return
+
+    if req.state in {Scheduled, InFlight}:
+      trace "Address already in pipeline", address, state = req.state
+      return
+
+    if self.retriesExhausted(address):
+      trace "Retries exhausted, skipping block", address
+      await self.failWantHandle(
+        address, RetriesExhaustedEngineError, "Block request retries exhausted"
+      )
+      return
+
+    if self.getPeerForBlock.isNil:
+      trace "No peer selector configured", address
+      raiseAssert("No peer selector configured")
+      return
+
+    without peer =? await self.getPeerForBlock(address), err:
+      trace "Unable to get peer", address, err = err.msg
+      if err of NoPeerForBlockError:
+        req.state = Pending
+        await self.retryAddresses(@[address])
+      return
+
+    var batchReq: BatchReq
+    self.byPeer.withValue(peer.id, existing):
+      batchReq = existing[]
+    do:
+      batchReq = BatchReq(peer: peer, pipe: newAsyncQueue[BlockAddress](128))
+      self.byPeer[peer.id] = batchReq
+      self.trackedFutures.track(self.peerBatchWorker(batchReq))
+
+      # Register disconnect monitor on first use of this peer
+      proc disconnectMonitor() {.async: (raises: []).} =
+        try:
+          await peer.onDisconnect()
+        except CatchableError as exc:
+          warn "Exception in disconnect monitor", exc = exc.msg
+
+        # Requeue all blocks assigned to this peer
+        var addrs: seq[BlockAddress]
+        for addr, req in self.blocks:
+          if req.requestedPeer == peer:
+            addrs.add(addr)
+        if addrs.len > 0:
+          await self.retryAddresses(addrs)
+
+        # Clean up byPeer entry
+        self.byPeer.del(peer.id)
+
+      self.trackedFutures.track(disconnectMonitor())
+
+    await batchReq.pipe.put(address)
+    req.state = Scheduled
+  except CatchableError as exc:
+    trace "Exception pushing block to peer worker", address, exc = exc.msg
+
+proc blockRequestScheduler(self: PendingBlocksManager) {.async: (raises: []).} =
+  try:
+    while self.running:
+      if self.blockQueue.len == 0:
+        await self.queueWakeEvent.wait()
+        self.queueWakeEvent.clear()
+        continue
+
+      let
+        item = self.blockQueue[0]
+        now = Moment.now()
+
+      if item.readyAt > now:
+        let timer = sleepAsync(item.readyAt - now)
+        await timer or self.queueWakeEvent.wait()
+        await noCancel timer.cancelAndWait()
+        self.queueWakeEvent.clear()
+        continue
+
+      let
+        blockReq = self.blockQueue.pop()
+        address = blockReq.address
+
+      without req =? self.blocks .? [address], err:
+        trace "Request don't seem to exist", err = err.msg
+        continue
+
+      if blockReq.generation != req.generation:
+        trace "Block generation don't match, stale block", address
+        continue
+
+      req.state = Dispatching
+      self.trackedFutures.track(self.pushPeerBlock(address))
+      await sleepAsync(0.millis)
+  except CatchableError as exc:
+    trace "Exception in block request scheduler", err = exc.msg
+
+# --- Lifecycle ---
+
+proc start*(self: PendingBlocksManager) {.async: (raises: []).} =
+  if self.running:
+    trace "Block scheduler already running"
     return
 
-  if req.handle.finished or req.requested.isSome or req.queued or req.scheduled or
-      req.discoveryWaiting or req.eligibleAt > Moment.now():
-    return
+  self.running = true
+  self.trackedFutures.track(self.blockRequestScheduler())
 
-  req.priority = priority
-  req.scheduled = true
-  req.queued = true
-  req.insertedAt = Moment.now()
-  await self.readyQueue.push(req)
+proc stop*(self: PendingBlocksManager) {.async: (raises: []).} =
+  if not self.running:
+    trace "Block scheduler not running"
 
-proc dequeue*(
-    self: PendingBlocksManager
-): Future[BlockAddress] {.async: (raises: [CancelledError]).} =
-  while true:
-    let req = await self.readyQueue.pop()
-    req.queued = false
+  self.running = false
+  self.queueWakeEvent.fire()
 
-    if current =? self.blocks .? [req.address]:
-      if current == BlockReq(req):
-        return req.address
+  self.blockQueue.clear()
+  self.byPeer.clear()
 
-func isQueued*(self: PendingBlocksManager, address: BlockAddress): bool =
-  if req =? self.blocks .? [address]:
-    return req.queued
-  false
+  var handles: seq[BlockHandle]
+  for req in self.blocks.values:
+    handles.add(req.handle)
+    for owner in req.owners:
+      handles.add(owner)
 
-proc isEligible*(self: PendingBlocksManager, address: BlockAddress): bool =
-  if req =? self.blocks .? [address]:
-    return req.eligibleAt <= Moment.now()
-  false
+  let cancellations = handles.mapIt(it.cancelAndWait())
+  await noCancel allFutures(cancellations)
 
-func isDiscoveryWaiting*(self: PendingBlocksManager, address: BlockAddress): bool =
-  if req =? self.blocks .? [address]:
-    return req.discoveryWaiting
-  false
+  self.handles.clear()
+  self.blocks.clear()
+  self.updatePendingBlockGauge()
 
-proc setEligibleAt*(
-    self: PendingBlocksManager, address: BlockAddress, deadline: Duration
-) =
-  if req =? self.blocks .? [address]:
-    req.eligibleAt = Moment.now() + deadline
-    req.scheduled = false
-
-proc markDispatched*(self: PendingBlocksManager, address: BlockAddress) =
-  if req =? self.blocks .? [address]:
-    req.scheduled = false
-
-proc enterDiscoveryWait*(
-    self: PendingBlocksManager, address: BlockAddress, deadline: Duration
-) =
-  if req =? self.blocks .? [address]:
-    req.discoveryWaiting = true
-    req.discoveryDeadline = Moment.now() + deadline
-    req.scheduled = false
-
-proc wakeOnPresence*(self: PendingBlocksManager, address: BlockAddress) =
-  if req =? self.blocks .? [address]:
-    req.discoveryWaiting = false
-    if not req.queued and not req.requested.isSome and req.eligibleAt <= Moment.now():
-      req.queued = true
-      req.scheduled = true
-      if err =? self.readyQueue.pushNoWait(req).errorOption:
-        req.queued = false
-        req.scheduled = false
-        trace "Ready queue full, cannot wake", address, err = $err
+  await noCancel self.trackedFutures.cancelTracked()
 
 func new*(
-    T: type PendingBlocksManager, retries = DefaultBlockRetries
+    T: type PendingBlocksManager,
+    retries = DefaultBlockRetries,
+    batchSize = DefaultMaxBatchBlocks,
+    batchDeadline = DefaultMaxBatchBlocksTimeout,
+    discoveryTimeout = DefaultDiscoveryWaitTimeout,
+    sendBatch: BatchSendHandler = nil,
+    onAbandon: AbandonHandler = nil,
+    onTimeout: TimeoutHandler = nil,
+    getPeerForBlock: PeerSelectorHandler = nil,
 ): PendingBlocksManager =
   PendingBlocksManager(
-    blockRetries: retries,
-    handleMonitors: TrackedFutures.new(),
-    readyQueue: newAsyncHeapQueue[SchedulableReq](),
+    retries: retries,
+    batchSize: batchSize,
+    batchDeadline: batchDeadline,
+    discoveryTimeout: discoveryTimeout,
+    trackedFutures: TrackedFutures.new(),
+    queueWakeEvent: newAsyncEvent(),
+    sendBatch: sendBatch,
+    getPeerForBlock: getPeerForBlock,
+    onAbandon: onAbandon,
+    onTimeout: onTimeout,
   )

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -231,7 +231,7 @@ func len*(self: PendingBlocksManager): int =
 proc retryAddresses*(
   self: PendingBlocksManager,
   addresses: seq[BlockAddress],
-  delay: Duration = DefaultDiscoveryWaitTimeout,
+  delay: Duration = DefaultBlockSendRetryDelay,
 ) {.async: (raises: []).}
 
 proc clearPeerAssignment(
@@ -242,10 +242,12 @@ proc clearPeerAssignment(
       timeoutFut = req.requestTimeout
       assignedPeer = req.requestedPeer
 
-    # Detach synchronously -- no other async task can observe stale state
+    # Detach synchronously - no other async task can observe stale state
     req.requestTimeout = nil
     req.requestedPeer = nil
+    req.state = Pending
     if assignedPeer != nil:
+      trace "Clearing peer assignment for block", address, peer = assignedPeer.id
       assignedPeer.blockRequestCleared(address)
 
     # Now safely cancel the timeout monitor
@@ -406,13 +408,12 @@ proc markRequested*(
     address: BlockAddress,
     peer: BlockExcPeerCtx,
     timeout: Duration = DefaultRequestTimeout,
-): BlockExcPeerCtx =
-  let prevPeer = self.getRequestPeerCtx(address)
-  if prevPeer != nil:
-    trace "Block already requested", address, requestedPeer = prevPeer.id
-    return prevPeer
-
+) =
   if var pending =? self.blocks .? [address]:
+    if pending.requestedPeer != nil and pending.state == InFlight:
+      trace "Block already requested", address, requestedPeer = pending.requestedPeer.id
+      return
+
     pending.requestedPeer = peer
     pending.state = InFlight
     pending.retries -= 1
@@ -456,8 +457,6 @@ proc markRequested*(
     pending.requestTimeout = currentMonitor
     self.trackedFutures.track(currentMonitor)
 
-    return pending.requestedPeer
-
 proc clearRequest*(
     self: PendingBlocksManager, address: BlockAddress
 ) {.async: (raises: []).} =
@@ -473,9 +472,11 @@ proc clearRequest*(
 proc retryAddresses*(
     self: PendingBlocksManager,
     addresses: seq[BlockAddress],
-    delay: Duration = DefaultDiscoveryWaitTimeout,
+    delay: Duration = DefaultBlockSendRetryDelay,
 ) {.async: (raises: []).} =
   for address in addresses:
+    trace "Retrying address", address
+
     without req =? self.blocks .? [address]:
       continue
 
@@ -499,13 +500,13 @@ proc retryAddresses*(
   self.queueWakeEvent.fire()
 
 proc peerBatchWorker(
-    self: PendingBlocksManager, batchReq: sink BatchReq
+    self: PendingBlocksManager, batchReq: BatchReq
 ) {.async: (raises: []).} =
   defer:
     # make sure to drain the queue if we're exiting
     # while the engine is still running
     if self.running and not batchReq.pipe.empty():
-      await self.retryAddresses(batchReq.pipe.toSeq)
+      await self.retryAddresses(batchReq.pipe.toSeq, self.discoveryTimeout)
 
   proc validateBlock(
       address: BlockAddress
@@ -533,6 +534,8 @@ proc peerBatchWorker(
 
       # Get first item (blocking wait)
       let first = await batchReq.pipe.get()
+      trace "Scheduling peer block", address = first, peer = batchReq.peer.id
+
       if not await validateBlock(first):
         trace "Block validation failed", address = first
         continue
@@ -560,12 +563,12 @@ proc peerBatchWorker(
       trace "Dispatching batch to peer", peer = batchReq.peer.id, batch = batch.len
 
       for address in batch:
-        discard self.markRequested(address, batchReq.peer)
+        self.markRequested(address, batchReq.peer)
 
       if not self.sendBatch.isNil and batch.len > 0:
         if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
           warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
-          await self.retryAddresses(batch)
+          await self.retryAddresses(batch, self.discoveryTimeout)
   except CatchableError as exc:
     trace "Exception in peer batch worker", exc = exc.msg
 
@@ -590,14 +593,13 @@ proc pushPeerBlock(
 
     if self.getPeerForBlock.isNil:
       trace "No peer selector configured", address
-      raiseAssert("No peer selector configured")
       return
 
     without peer =? await self.getPeerForBlock(address), err:
       trace "Unable to get peer", address, err = err.msg
       if err of NoPeerForBlockError:
         req.state = Pending
-        await self.retryAddresses(@[address])
+        await self.retryAddresses(@[address], self.discoveryTimeout)
       return
 
     var batchReq: BatchReq

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -101,10 +101,12 @@ type
     generation: int
     priority: int
 
-  BatchReq = object
+  BatchReq = ref object
     peer: BlockExcPeerCtx
     deadline: Future[void]
     pipe: AsyncQueue[BlockAddress]
+    workerFut: Future[void].Raising([])
+    monitorFut: Future[void].Raising([])
 
   PendingBlocksManager* = ref object of RootObj
     blocks: Table[BlockAddress, BlockReq]
@@ -602,40 +604,41 @@ proc pushPeerBlock(
     self.byPeer.withValue(peer.id, existing):
       batchReq = existing[]
     do:
-      batchReq = BatchReq(peer: peer, pipe: newAsyncQueue[BlockAddress](128))
+      trace "Creating new peer request worker", peer = peer.id
+      batchReq = BatchReq(peer: peer, pipe: newAsyncQueue[BlockAddress](self.batchSize))
       self.byPeer[peer.id] = batchReq
-      let workerFut = self.peerBatchWorker(batchReq)
-      self.trackedFutures.track(workerFut)
+      batchReq.workerFut = self.peerBatchWorker(batchReq)
+      self.trackedFutures.track(batchReq.workerFut)
 
       # Register disconnect monitor on first use of this peer
       proc disconnectMonitor() {.async: (raises: []).} =
         try:
+          trace "Monitoring peer disconnect", peer = peer.id
           await peer.onDisconnect()
         except CatchableError as exc:
           warn "Exception in disconnect monitor", exc = exc.msg
 
         trace "Peer disconnected, performing cleanup", peer = peer.id
-        await noCancel workerFut.cancelAndWait()
+        await noCancel batchReq.workerFut.cancelAndWait()
         # Requeue all blocks assigned to this peer
 
         let
           blocks = peer.blocksRequested.toSeq
-          failed = (
-            await noCancel allFinishedFailed[void](
-              blocks.mapIt(self.clearPeerAssignment(it))
-            )
-          )[1]
+          (_, failed) = await noCancel allFinishedFailed[void](
+            blocks.mapIt(self.clearPeerAssignment(it))
+          )
 
         if failed.len > 0:
           trace "Not all blocks peer assignments were cleared", failed = failed.len
 
         if blocks.len > 0:
-          await self.retryAddresses(blocks)
+          await self.retryAddresses(blocks, self.discoveryTimeout)
 
         # Clean up byPeer entry
         self.byPeer.del(peer.id)
 
-      self.trackedFutures.track(disconnectMonitor())
+      batchReq.monitorFut = disconnectMonitor()
+      self.trackedFutures.track(batchReq.monitorFut)
 
     req.state = Scheduled
     req.requestedPeer = batchReq.peer

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -522,6 +522,8 @@ proc peerBatchWorker(
       )
       return false
 
+    return true
+
   try:
     while self.running:
       var batch: seq[BlockAddress] = @[]

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -504,9 +504,35 @@ proc peerBatchWorker(
     if self.running and not batchReq.pipe.empty():
       await self.retryAddresses(batchReq.pipe.toSeq)
 
+  proc validateBlock(
+      address: BlockAddress
+  ): Future[bool] {.async: (raises: [CancelledError]).} =
+    without req =? self.blocks .? [address]:
+      trace "Address is not pending", address
+      return false
+
+    if req.state in {Dispatching, InFlight}:
+      trace "Address already in pipeline, skipping", address, state = req.state
+      return false
+
+    if self.retriesExhausted(address):
+      trace "Retries exhausted, skipping block", address
+      await self.failWantHandle(
+        address, RetriesExhaustedEngineError, "Block request retries exhausted"
+      )
+      return false
+
   try:
     while self.running:
-      var batch: seq[BlockAddress] = @[await batchReq.pipe.get()]
+      var batch: seq[BlockAddress] = @[]
+
+      # Get first item (blocking wait)
+      let first = await batchReq.pipe.get()
+      if not await validateBlock(first):
+        trace "Block validation failed", address = first
+        continue
+
+      batch.add(first)
 
       batchReq.deadline = sleepAsync(self.batchDeadline)
       defer:
@@ -520,19 +546,8 @@ proc peerBatchWorker(
             trace "Deadline reached", peer = batchReq.peer.id
             break
 
-        without req =? self.blocks .? [address]:
-          trace "Address is not pending", address
-          continue
-
-        if req.state in {Dispatching, InFlight}:
-          trace "Address already in pipeline, skipping", address, state = req.state
-          continue
-
-        if self.retriesExhausted(address):
-          trace "Retries exhausted, skipping block", address
-          await self.failWantHandle(
-            address, RetriesExhaustedEngineError, "Block request retries exhausted"
-          )
+        if not await validateBlock(address):
+          trace "Block validation failed", address
           continue
 
         batch.add(address)
@@ -545,9 +560,7 @@ proc peerBatchWorker(
       if not self.sendBatch.isNil and batch.len > 0:
         if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
           warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
-
-          if batchReq.peer.blocksRequested.len > 0:
-            await self.retryAddresses(batchReq.peer.blocksRequested.toSeq)
+          await self.retryAddresses(batch)
   except CatchableError as exc:
     trace "Exception in peer batch worker", exc = exc.msg
 
@@ -611,6 +624,7 @@ proc pushPeerBlock(
 
     await batchReq.pipe.put(address)
     req.state = Scheduled
+    batchReq.peer.blockRequestScheduled(address)
   except CatchableError as exc:
     trace "Exception pushing block to peer worker", address, exc = exc.msg
 

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -104,6 +104,7 @@ type
     peer: BlockExcPeerCtx
     deadline: Future[void]
     pipe: AsyncQueue[BlockAddress]
+    workerFut: Future[void].Raising([])
 
   PendingBlocksManager* = ref object of RootObj
     blocks: Table[BlockAddress, BlockReq]
@@ -591,7 +592,8 @@ proc pushPeerBlock(
     do:
       batchReq = BatchReq(peer: peer, pipe: newAsyncQueue[BlockAddress](128))
       self.byPeer[peer.id] = batchReq
-      self.trackedFutures.track(self.peerBatchWorker(batchReq))
+      batchReq.workerFut = self.peerBatchWorker(batchReq)
+      self.trackedFutures.track(batchReq.workerFut)
 
       # Register disconnect monitor on first use of this peer
       proc disconnectMonitor() {.async: (raises: []).} =
@@ -600,6 +602,7 @@ proc pushPeerBlock(
         except CatchableError as exc:
           warn "Exception in disconnect monitor", exc = exc.msg
 
+        await noCancel batchReq.workerFut.cancelAndWait()
         # Requeue all blocks assigned to this peer
         var addrs: seq[BlockAddress]
         if peer.blocksRequested.len > 0:

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -153,7 +153,7 @@ func retries*(self: PendingBlocksManager, address: BlockAddress): int =
   if pending =? self.blocks .? [address]: pending.retries else: 0
 
 func decRetries*(self: PendingBlocksManager, address: BlockAddress) =
-  if var pending =? self.blocks .? [address]:
+  if pending =? self.blocks .? [address]:
     pending.retries -= 1
 
 func retriesExhausted*(self: PendingBlocksManager, address: BlockAddress): bool =
@@ -239,7 +239,7 @@ proc retryAddresses*(
 proc clearPeerAssignment(
     self: PendingBlocksManager, address: BlockAddress
 ) {.async: (raises: []).} =
-  if var req =? self.blocks .? [address]:
+  if req =? self.blocks .? [address]:
     let
       timeoutFut = req.requestTimeout
       assignedPeer = req.requestedPeer
@@ -261,7 +261,7 @@ proc releaseWantHandle(
 ): Future[?!void] {.async: (raises: []), gcsafe.} =
   if address =? self.handles .? [wrapped]:
     self.handles.del(wrapped)
-    if var req =? self.blocks .? [address]:
+    if req =? self.blocks .? [address]:
       req.owners.excl(wrapped)
       if req.owners.len == 0:
         if not req.handle.finished:
@@ -283,7 +283,7 @@ proc releaseWantHandle(
 proc addOwner(
     self: PendingBlocksManager, address: BlockAddress, priority = 0
 ): BlockHandle {.gcsafe.} =
-  if var pending =? self.blocks .? [address]:
+  if pending =? self.blocks .? [address]:
     let wrapped = pending.handle.wrap()
 
     pending.owners.incl(wrapped)
@@ -344,7 +344,7 @@ proc getWantHandle*(
       except CatchableError as exc:
         trace "Exception in handle monitor", exc = exc.msg
 
-      if var req =? self.blocks .? [address]:
+      if req =? self.blocks .? [address]:
         await self.clearPeerAssignment(address)
 
       self.blocks.del(address)
@@ -412,7 +412,7 @@ proc markRequested*(
     peer: BlockExcPeerCtx,
     timeout: Duration = DefaultRequestTimeout,
 ) =
-  if var pending =? self.blocks .? [address]:
+  if pending =? self.blocks .? [address]:
     if pending.requestedPeer != nil and pending.state == InFlight:
       trace "Block already requested", address, requestedPeer = pending.requestedPeer.id
       return
@@ -445,7 +445,7 @@ proc markRequested*(
       if timeoutFut.completed:
         # Requeue the block for retry before notifying the engine.
         # Only if we still own the assignment (no concurrent clear/resolve).
-        if var req =? self.blocks .? [address]:
+        if req =? self.blocks .? [address]:
           if req.requestTimeout == currentMonitor and req.requestedPeer == peer:
             req.requestedPeer.blockRequestCleared(address)
             req.requestedPeer = nil

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -105,7 +105,6 @@ type
     peer: BlockExcPeerCtx
     deadline: Future[void]
     pipe: AsyncQueue[BlockAddress]
-    workerFut: Future[void].Raising([])
 
   PendingBlocksManager* = ref object of RootObj
     blocks: Table[BlockAddress, BlockReq]
@@ -261,7 +260,6 @@ proc releaseWantHandle(
       if req.owners.len == 0:
         if not req.handle.finished:
           warn "Abandoning block", address
-          await self.clearPeerAssignment(address)
           req.handle.fail(
             newException(RequestAbandonedEngineError, fmt"Abandoning block {address}")
           )
@@ -269,6 +267,7 @@ proc releaseWantHandle(
           if not self.onAbandon.isNil:
             trace "Handle abandoned, running on abandon hook", address
             await noCancel self.onAbandon(address)
+          await self.clearPeerAssignment(address)
 
       self.queueWakeEvent.fire()
       return success()
@@ -605,8 +604,8 @@ proc pushPeerBlock(
     do:
       batchReq = BatchReq(peer: peer, pipe: newAsyncQueue[BlockAddress](128))
       self.byPeer[peer.id] = batchReq
-      batchReq.workerFut = self.peerBatchWorker(batchReq)
-      self.trackedFutures.track(batchReq.workerFut)
+      let workerFut = self.peerBatchWorker(batchReq)
+      self.trackedFutures.track(workerFut)
 
       # Register disconnect monitor on first use of this peer
       proc disconnectMonitor() {.async: (raises: []).} =
@@ -615,20 +614,33 @@ proc pushPeerBlock(
         except CatchableError as exc:
           warn "Exception in disconnect monitor", exc = exc.msg
 
-        await noCancel batchReq.workerFut.cancelAndWait()
+        trace "Peer disconnected, performing cleanup", peer = peer.id
+        await noCancel workerFut.cancelAndWait()
         # Requeue all blocks assigned to this peer
-        var addrs: seq[BlockAddress]
-        if peer.blocksRequested.len > 0:
-          await self.retryAddresses(peer.blocksRequested.toSeq)
+
+        let
+          blocks = peer.blocksRequested.toSeq
+          failed = (
+            await noCancel allFinishedFailed[void](
+              blocks.mapIt(self.clearPeerAssignment(it))
+            )
+          )[1]
+
+        if failed.len > 0:
+          trace "Not all blocks peer assignments were cleared", failed = failed.len
+
+        if blocks.len > 0:
+          await self.retryAddresses(blocks)
 
         # Clean up byPeer entry
         self.byPeer.del(peer.id)
 
       self.trackedFutures.track(disconnectMonitor())
 
-    await batchReq.pipe.put(address)
     req.state = Scheduled
+    req.requestedPeer = batchReq.peer
     batchReq.peer.blockRequestScheduled(address)
+    await batchReq.pipe.put(address)
   except CatchableError as exc:
     trace "Exception pushing block to peer worker", address, exc = exc.msg
 

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -683,7 +683,10 @@ proc blockRequestScheduler(self: PendingBlocksManager) {.async: (raises: []).} =
         let timer = sleepAsync(item.readyAt - now)
         await timer or self.queueWakeEvent.wait()
         await noCancel timer.cancelAndWait()
-        self.queueWakeEvent.clear()
+        if not self.queueWakeEvent.isSet():
+          self.queueWakeEvent.clear()
+
+      if self.blockQueue.len == 0:
         continue
 
       let

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -95,7 +95,7 @@ type
     addedAt: Moment
     readyAt: Moment
 
-  BlockItem* = object
+  BlockItem = object
     address: BlockAddress
     readyAt: Moment
     addedAt: Moment

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -54,6 +54,7 @@ const
   DefaultRequestTimeout* = 30.seconds
   DefaultDiscoveryWaitTimeout = 5.seconds
   DefaultBlockSendRetryDelay* = 500.millis
+  DefaultYieldInterval = 5.millis
 
 type
   BlockHandle* = Future[BlockDelivery].Raising([CancelledError, EngineError])
@@ -119,6 +120,7 @@ type
     retries = DefaultBlockRetries
     running: bool
     trackedFutures: TrackedFutures
+    yieldInterval: Duration
 
     onAbandon*: AbandonHandler
     onTimeout*: TimeoutHandler
@@ -632,6 +634,7 @@ proc pushPeerBlock(
 
 proc blockRequestScheduler(self: PendingBlocksManager) {.async: (raises: []).} =
   try:
+    var nextYield = Moment.now() + self.yieldInterval
     while self.running:
       if self.blockQueue.len == 0:
         await self.queueWakeEvent.wait()
@@ -669,7 +672,11 @@ proc blockRequestScheduler(self: PendingBlocksManager) {.async: (raises: []).} =
 
       # TODO: This needs to be changed sleep/idleAsync
       # after some budget has been consumed
-      await sleepAsync(0.millis)
+      if Moment.now() > nextYield:
+        nextYield = Moment.now() + self.yieldInterval
+        trace "Yielding in scheduler loop",
+          nextYield = nextYield, interval = self.yieldInterval
+        await sleepAsync(0.millis)
   except CatchableError as exc:
     trace "Exception in block request scheduler", err = exc.msg
 
@@ -712,6 +719,7 @@ func new*(
     batchSize = DefaultMaxBatchBlocks,
     batchDeadline = DefaultMaxBatchBlocksTimeout,
     discoveryTimeout = DefaultDiscoveryWaitTimeout,
+    yieldInterval = DefaultYieldInterval,
     sendBatch: BatchSendHandler = nil,
     onAbandon: AbandonHandler = nil,
     onTimeout: TimeoutHandler = nil,
@@ -724,6 +732,7 @@ func new*(
     discoveryTimeout: discoveryTimeout,
     trackedFutures: TrackedFutures.new(),
     queueWakeEvent: newAsyncEvent(),
+    yieldInterval: yieldInterval,
     sendBatch: sendBatch,
     getPeerForBlock: getPeerForBlock,
     onAbandon: onAbandon,

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -435,10 +435,6 @@ proc markRequested*(
         trace "Exiting timeout monitor, handle finished", address, peer = peer.id
         return
 
-      if var req =? self.blocks .? [address]:
-        if req.requestTimeout == currentMonitor:
-          req.requestTimeout = nil
-
       if timeoutFut.completed:
         # Requeue the block for retry before notifying the engine.
         # Only if we still own the assignment (no concurrent clear/resolve).

--- a/archivist/blockexchange/engine/pendingblocks.nim
+++ b/archivist/blockexchange/engine/pendingblocks.nim
@@ -225,9 +225,9 @@ func len*(self: PendingBlocksManager): int =
   self.blocks.len
 
 proc retryAddresses*(
-    self: PendingBlocksManager,
-    addresses: seq[BlockAddress],
-    delay: Duration = DefaultDiscoveryWaitTimeout,
+  self: PendingBlocksManager,
+  addresses: seq[BlockAddress],
+  delay: Duration = DefaultDiscoveryWaitTimeout,
 ) {.async: (raises: []).}
 
 proc clearPeerAssignment(
@@ -501,6 +501,12 @@ proc retryAddresses*(
 proc peerBatchWorker(
     self: PendingBlocksManager, batchReq: sink BatchReq
 ) {.async: (raises: []).} =
+  defer:
+    # make sure to drain the queue if we're exiting
+    # while the engine is still running
+    if self.running and not batchReq.pipe.empty():
+      await self.retryAddresses(batchReq.pipe.toSeq)
+
   try:
     while self.running:
       var batch: seq[BlockAddress] = @[await batchReq.pipe.get()]
@@ -536,20 +542,15 @@ proc peerBatchWorker(
 
       trace "Dispatching batch to peer", peer = batchReq.peer.id, batch = batch.len
 
-      # Mark all as in-flight BEFORE calling engine
       for address in batch:
         discard self.markRequested(address, batchReq.peer)
 
       if not self.sendBatch.isNil and batch.len > 0:
         if err =? (await self.sendBatch(batchReq.peer, batch)).errorOption:
           warn "Batch send failed, requeuing", peer = batchReq.peer.id, err = err.msg
-          var toRetry: seq[BlockAddress]
-          for address in batch:
-            if req =? self.blocks .? [address]:
-              if req.requestedPeer == batchReq.peer:
-                toRetry.add(address)
-          if toRetry.len > 0:
-            await self.retryAddresses(toRetry)
+
+          if batchReq.peer.blocksRequested.len > 0:
+            await self.retryAddresses(batchReq.peer.blocksRequested.toSeq)
   except CatchableError as exc:
     trace "Exception in peer batch worker", exc = exc.msg
 
@@ -601,11 +602,8 @@ proc pushPeerBlock(
 
         # Requeue all blocks assigned to this peer
         var addrs: seq[BlockAddress]
-        for addr, req in self.blocks:
-          if req.requestedPeer == peer:
-            addrs.add(addr)
-        if addrs.len > 0:
-          await self.retryAddresses(addrs)
+        if peer.blocksRequested.len > 0:
+          await self.retryAddresses(peer.blocksRequested.toSeq)
 
         # Clean up byPeer entry
         self.byPeer.del(peer.id)
@@ -649,12 +647,16 @@ proc blockRequestScheduler(self: PendingBlocksManager) {.async: (raises: []).} =
         continue
 
       req.state = Dispatching
+      # We need to spawn a task, because pushPeerBlock
+      # might need to await for peers and we don't want
+      # to hold up the dispatch loop
       self.trackedFutures.track(self.pushPeerBlock(address))
+
+      # TODO: This needs to be changed sleep/idleAsync
+      # after some budget has been consumed
       await sleepAsync(0.millis)
   except CatchableError as exc:
     trace "Exception in block request scheduler", err = exc.msg
-
-# --- Lifecycle ---
 
 proc start*(self: PendingBlocksManager) {.async: (raises: []).} =
   if self.running:

--- a/archivist/blockexchange/peers/peercontext.nim
+++ b/archivist/blockexchange/peers/peercontext.nim
@@ -38,6 +38,7 @@ type BlockExcPeerCtx* = ref object of RootObj
   blocksRequested*: HashSet[BlockAddress]
   activityTimeout*: Duration
   lastSentWants*: HashSet[BlockAddress]
+  disconnected: Future[void] # completed when peer is removed from store
 
 proc isKnowledgeStale*(self: BlockExcPeerCtx): bool =
   let staleness =
@@ -107,7 +108,7 @@ func cleanPresence*(self: BlockExcPeerCtx, address: BlockAddress) =
 proc blockRequestScheduled*(self: BlockExcPeerCtx, address: BlockAddress) =
   self.blocksRequested.incl(address)
 
-proc blockRequestCancelled*(self: BlockExcPeerCtx, address: BlockAddress) =
+proc blockRequestCleared*(self: BlockExcPeerCtx, address: BlockAddress) =
   self.blocksRequested.excl(address)
 
 proc isBlockRequested*(self: BlockExcPeerCtx, address: BlockAddress): bool =
@@ -116,9 +117,22 @@ proc isBlockRequested*(self: BlockExcPeerCtx, address: BlockAddress): bool =
 proc blockRequestAccepted*(self: BlockExcPeerCtx, address: BlockAddress) =
   self.blocksRequested.excl(address)
 
+proc disconnect*(self: BlockExcPeerCtx) =
+  ## Complete the disconnected future, signaling lifecycle end
+  if not self.disconnected.finished:
+    self.disconnected.complete()
+
+proc onDisconnect*(
+    self: BlockExcPeerCtx
+): Future[void] {.async: (raw: true, raises: [CancelledError]).} =
+  ## Await this to be notified when the peer is removed from the store
+  self.disconnected.join()
+
 proc new*(
     T: type BlockExcPeerCtx,
     peerId: PeerId,
     activityTimeout = DefaultPeerActivityTimeout,
 ): BlockExcPeerCtx =
-  BlockExcPeerCtx(id: peerId, activityTimeout: activityTimeout)
+  BlockExcPeerCtx(
+    id: peerId, activityTimeout: activityTimeout, disconnected: newFuture[void]()
+  )

--- a/archivist/blockexchange/peers/peerctxstore.nim
+++ b/archivist/blockexchange/peers/peerctxstore.nim
@@ -46,11 +46,18 @@ func peerIds*(self: PeerCtxStore): seq[PeerId] =
 func contains*(self: PeerCtxStore, peerId: PeerId): bool =
   peerId in self.peers
 
-func add*(self: PeerCtxStore, peer: BlockExcPeerCtx) =
+proc add*(self: PeerCtxStore, peer: BlockExcPeerCtx) =
+  let existing = self.peers.getOrDefault(peer.id, nil)
+  if not existing.isNil and existing != peer:
+    existing.disconnect() # disconnect stale context
   self.peers[peer.id] = peer
 
-func remove*(self: PeerCtxStore, peerId: PeerId) =
-  self.peers.del(peerId)
+proc remove*(self: PeerCtxStore, peerId: PeerId) =
+  if peerId in self.peers:
+    let peer = self.peers.getOrDefault(peerId, nil)
+    self.peers.del(peerId)
+    if not peer.isNil:
+      peer.disconnect()
 
 func get*(self: PeerCtxStore, peerId: PeerId): BlockExcPeerCtx =
   self.peers.getOrDefault(peerId, nil)

--- a/archivist/discovery.nim
+++ b/archivist/discovery.nim
@@ -35,6 +35,10 @@ export discv5
 logScope:
   topics = "archivist discovery"
 
+const
+  DefaultDhtRefreshCooldown* = 5.seconds
+  DefaultDhtMinPeers* = BUCKET_SIZE
+
 type Discovery* = ref object of RootObj
   protocol*: discv5.Protocol # dht protocol
   key: PrivateKey # private key
@@ -44,6 +48,10 @@ type Discovery* = ref object of RootObj
     # record to advertice node connection information, this carry any
     # address that the node can be connected on
   dhtRecord*: ?SignedPeerRecord # record to advertice DHT connection information
+  lastDhtRefreshAt: Moment # Cooldown timestamp for dht refresh
+  refreshRoutingTableFut: Future[void].Raising([]) # Tracked background refresh task
+
+proc ensureDhtPopulated*(d: Discovery) {.gcsafe.}
 
 proc toNodeId*(cid: Cid): NodeId =
   ## Cid to discovery id
@@ -65,6 +73,7 @@ proc findPeer*(
   ##
 
   try:
+    d.ensureDhtPopulated()
     let node = await d.protocol.resolve(toNodeId(peerId))
 
     return
@@ -87,6 +96,7 @@ method find*(
   ##
 
   try:
+    d.ensureDhtPopulated()
     without providers =? (await d.protocol.getProviders(cid.toNodeId())).mapFailure,
       error:
       warn "Error finding providers for block", cid, error = error.msg
@@ -102,6 +112,7 @@ method provide*(d: Discovery, cid: Cid) {.async: (raises: [CancelledError]), bas
   ## Provide a block Cid
   ##
   try:
+    d.ensureDhtPopulated()
     let nodes = await d.protocol.addProvider(cid.toNodeId(), d.providerRecord.get)
 
     if nodes.len <= 0:
@@ -112,6 +123,44 @@ method provide*(d: Discovery, cid: Cid) {.async: (raises: [CancelledError]), bas
   except CatchableError as exc:
     warn "Error providing block", cid, exc = exc.msg
 
+proc nodesDiscovered*(d: Discovery): int =
+  if d.protocol.isNil:
+    return 0
+
+  d.protocol.nodesDiscovered()
+
+proc refreshRoutingTable*(
+    d: Discovery
+): Future[int] {.async: (raises: [CancelledError]).} =
+  if d.protocol.isNil:
+    return 0
+
+  try:
+    discard await d.protocol.queryRandom()
+  except CatchableError as exc:
+    trace "Routing table refresh failed", exc = exc.msg
+
+  d.nodesDiscovered()
+
+proc refreshRoutingTableBackground(d: Discovery) {.async: (raises: []).} =
+  try:
+    discard await d.refreshRoutingTable()
+  except CatchableError as exc:
+    trace "Background routing table refresh failed", exc = exc.msg
+
+proc ensureDhtPopulated*(d: Discovery) {.gcsafe.} =
+  if not d.refreshRoutingTableFut.isNil and not d.refreshRoutingTableFut.finished:
+    return
+
+  if (Moment.now() - d.lastDhtRefreshAt) < DefaultDhtRefreshCooldown:
+    return
+
+  if d.nodesDiscovered() >= DefaultDhtMinPeers:
+    return
+
+  d.lastDhtRefreshAt = Moment.now()
+  d.refreshRoutingTableFut = refreshRoutingTableBackground(d)
+
 method find*(
     d: Discovery, host: ca.Address
 ): Future[seq[SignedPeerRecord]] {.async: (raises: [CancelledError]), base.} =
@@ -120,6 +169,7 @@ method find*(
 
   try:
     trace "Finding providers for host", host = $host
+    d.ensureDhtPopulated()
     without var providers =? (await d.protocol.getProviders(host.toNodeId())).mapFailure,
       error:
       trace "Error finding providers for host", host = $host, exc = error.msg
@@ -147,6 +197,7 @@ method provide*(
 
   try:
     trace "Providing host", host = $host
+    d.ensureDhtPopulated()
     let nodes = await d.protocol.addProvider(host.toNodeId(), d.providerRecord.get)
     if nodes.len > 0:
       trace "Provided to nodes", nodes = nodes.len
@@ -205,6 +256,11 @@ proc start*(d: Discovery) {.async: (raises: []).} =
     error "Error starting discovery", exc = exc.msg
 
 proc stop*(d: Discovery) {.async: (raises: []).} =
+  if not d.refreshRoutingTableFut.isNil:
+    try:
+      await noCancel d.refreshRoutingTableFut.cancelAndWait()
+    except CatchableError as exc:
+      trace "Error cancelling background DHT refresh", exc = exc.msg
   if not d.protocol.isNil and not d.protocol.transport.isNil:
     try:
       await noCancel d.protocol.closeWait()

--- a/archivist/marketplace/sales/states/filled.nim
+++ b/archivist/marketplace/sales/states/filled.nim
@@ -78,6 +78,10 @@ method run*(
       return some State(SaleProving())
     else:
       let error = newException(HostMismatchError, "Slot filled by other host")
+      if not storage.isNil:
+        if slot =? data.slotInfo.slot:
+          if err =? (await storage.deleteSlot(slot.request.content.cid, slot.slotIndex)).errorOption:
+            error "Failed to clean up unneeded slot data", error = err.msg
       return some State(SaleErrored(error: error))
   except CancelledError as e:
     trace "SaleFilled.run was cancelled", error = e.msgDetail

--- a/archivist/marketplace/sales/states/filling.nim
+++ b/archivist/marketplace/sales/states/filling.nim
@@ -1,6 +1,9 @@
+import pkg/questionable/results
+
 import ../../../logutils
 import ../../../utils/exceptions
 import ../../abstractmarketplace
+import ../../storageinterface
 import ../statemachine
 import ../salesagent
 import ./filled
@@ -29,6 +32,7 @@ method run*(
 ): Future[?State] {.async: (raises: []).} =
   let data = SalesAgent(machine).data
   let marketplace = SalesAgent(machine).context.marketplace
+  let storage = SalesAgent(machine).context.storage
 
   logScope:
     slot = data.slotInfo
@@ -45,6 +49,10 @@ method run*(
       )
     except SlotStateMismatchError:
       debug "Slot is already filled, ignoring slot"
+      if not storage.isNil:
+        if err =?
+            (await storage.deleteSlot(slot.request.content.cid, slot.slotIndex)).errorOption:
+          error "Failed to clean up unneeded slot data", error = err.msg
       return some State(SaleIgnored(reprocessSlot: false))
     except MarketplaceError as e:
       return some State(SaleErrored(error: e))

--- a/archivist/node.nim
+++ b/archivist/node.nim
@@ -933,27 +933,29 @@ proc proveSlot*(
 proc deleteSlot*(
     self: ArchivistNodeRef, cid: Cid, slotIdx: uint64
 ): Future[?!void] {.async: (raises: [CancelledError]).} =
-  ## Handle slot failure - mark overlay as failed so maintenance will drop it
+  ## Handle slot failure - drop the slot overlay so proving stops for this slot.
+  ## The manifest tree overlay is deliberately NOT touched here - it is shared
+  ## by all slots under the same manifest. Dropping it would break local block
+  ## resolution for other active slots from the same request. The tree overlay
+  ## expires via maintenance when its TTL passes, or is cleaned up in bulk by
+  ## cleanupPurchaseOverlays when the entire purchase completes.
   ##
   logScope:
     cid = $cid
     slot = slotIdx
 
-  trace "Marking slot as failed"
+  trace "Deleting slot", slotIdx
 
   let manifest = ?await self.fetchManifest(cid)
+
   if not manifest.verifiable:
     warn "Attempting to fail a slot with a non-verifiable manifest", cid, slotIdx
 
   let slotCid = manifest.slotRoots[slotIdx]
 
-  # Delete slot overlay
+  # Delete slot overlay only - tree overlay is shared and left intact
   if err =? (await self.repoStore.dropOverlay(slotCid)).errorOption:
     warn "Error marking slot overlay failed", err = err.msg
-
-  # Delete mainfest overlay
-  if err =? (await self.repoStore.dropOverlay(manifest.treeCid)).errorOption:
-    warn "Error marking tree overlay failed", err = err.msg
 
   trace "Slot marked as failed"
 

--- a/archivist/stores/networkstore.nim
+++ b/archivist/stores/networkstore.nim
@@ -34,45 +34,6 @@ type NetworkStore* = ref object of BlockStore
   engine*: BlockExcEngine # blockexc decision engine
   localStore*: BlockStore # local block store
 
-proc awaitDelivery(
-    engine: BlockExcEngine, handle: BlockHandle
-): Future[?!BlockDelivery] {.async: (raises: [CancelledError]).} =
-  try:
-    let completed = await one(handle)
-    return success(await completed)
-  except CancelledError as exc:
-    await noCancel engine.releaseHandle(handle)
-    raise exc
-  except CatchableError as exc:
-    return failure(exc)
-
-proc collectDeliveries(
-    engine: BlockExcEngine, requests: seq[BlockHandle]
-): Future[seq[BlockDelivery]] {.async: (raises: [CancelledError]).} =
-  var
-    pending = requests
-    deliveries: seq[BlockDelivery]
-
-  try:
-    while pending.len > 0:
-      without completedFut =? catchAsync(await one(pending)), err:
-        error "Unable to get block from exchange engine", err = err.msg
-        break
-
-      pending.del(pending.find(completedFut))
-
-      without delivery =? catchAsync(await completedFut), err:
-        error "Unable to get block from exchange engine", err = err.msg
-        continue
-
-      deliveries.add(delivery)
-  except CancelledError as exc:
-    for handle in pending:
-      await noCancel engine.releaseHandle(handle)
-    raise exc
-
-  return deliveries
-
 method getBlocks*(
     self: NetworkStore, cids: seq[Cid]
 ): Future[?!seq[Block]] {.async: (raises: [CancelledError]).} =
@@ -98,12 +59,11 @@ method getBlocks*(
     if cid notin localCids:
       addresses.add(BlockAddress.init(cid))
 
-  var requests = ?self.engine.requestDeliveries(addresses)
-  var allBlocks = localBlocks
-  for delivery in await collectDeliveries(self.engine, requests):
-    allBlocks.add(delivery.blk)
+  let blocks = (await allFinished(?self.engine.requestDeliveries(addresses))).mapIt(
+    ?catchAsync(it.read.blk)
+  )
 
-  success(allBlocks)
+  success(localBlocks & blocks)
 
 method getBlock*(
     self: NetworkStore, cid: Cid
@@ -116,8 +76,8 @@ method getBlock*(
       error "Error getting block from local store", cid, err = err.msg
       return failure err
 
-    let handle = ?self.engine.requestDelivery(BlockAddress.init(cid))
-    let delivery = ?await self.engine.awaitDelivery(handle)
+    let delivery =
+      ?catchAsync(await (?self.engine.requestDelivery(BlockAddress.init(cid))))
     return success delivery.blk
 
   return success blk
@@ -133,8 +93,10 @@ method getBlock*(
       error "Error getting block from local store", treeCid, index, err = err.msg
       return failure err
 
-    let handle = ?self.engine.requestDelivery(BlockAddress.init(treeCid, index))
-    let delivery = ?await self.engine.awaitDelivery(handle)
+    let delivery =
+      ?catchAsync(
+        await (?self.engine.requestDelivery(BlockAddress.init(treeCid, index)))
+      )
     return success delivery.blk
 
   return success blk
@@ -167,12 +129,13 @@ method getBlocks*(
     if index notin localIndices:
       addresses.add(BlockAddress.init(treeCid, index))
 
-  var requests = ?self.engine.requestDeliveries(addresses)
-  var allBlocks = localBlocks
-  for delivery in await collectDeliveries(self.engine, requests):
-    allBlocks.add((delivery.address.index, delivery.blk))
+  let blocks = (await allFinished(?self.engine.requestDeliveries(addresses))).mapIt(
+    block:
+      let delivery = ?catchAsync(it.read)
+      (delivery.address.index, delivery.blk)
+  )
 
-  success allBlocks
+  success(localBlocks & blocks)
 
 method completeBlocks*(
     self: NetworkStore, treeCid: Cid, blocks: seq[(Natural, Block)]
@@ -294,8 +257,8 @@ method fetchManifest*(
 
   without manifest =? (await self.localStore.fetchManifest(cid)), err:
     if err of BlockNotFoundError:
-      let handle = ?self.engine.requestDelivery(BlockAddress.init(cid))
-      let delivery = ?await self.engine.awaitDelivery(handle)
+      let delivery =
+        ?catchAsync(await (?self.engine.requestDelivery(BlockAddress.init(cid))))
       return Manifest.decode(delivery.blk)
 
   return success manifest
@@ -352,9 +315,9 @@ method getBlocksAndProofs*(
     if index notin localIndices:
       addresses.add(BlockAddress.init(treeCid, index))
 
-  var requests = ?self.engine.requestDeliveries(addresses)
-  var allBlocks = localBlocks
-  for delivery in await collectDeliveries(self.engine, requests):
+  var blocks: seq[(Natural, Block, ArchivistProof)]
+  for request in await allFinished(?self.engine.requestDeliveries(addresses)):
+    let delivery = ?catchAsync(request.read)
     if not delivery.address.leaf:
       warn "Skipping non-leaf delivery for leaf request", address = delivery.address
       continue
@@ -363,9 +326,9 @@ method getBlocksAndProofs*(
       warn "Skipping leaf delivery without proof", address = delivery.address
       continue
 
-    allBlocks.add((delivery.address.index, delivery.blk, proof))
+    blocks.add((delivery.address.index, delivery.blk, proof))
 
-  success allBlocks
+  success(localBlocks & blocks)
 
 method getCidsAndProofs*(
     self: NetworkStore, treeCid: Cid, indices: seq[Natural]

--- a/archivist/utils/asyncheapqueue.nim
+++ b/archivist/utils/asyncheapqueue.nim
@@ -26,8 +26,8 @@ type
     ## will block when the queue reaches ``maxsize``, until an item is
     ## removed by "await get()".
     queueType: QueueType
-    getters: seq[Future[void]]
-    putters: seq[Future[void]]
+    getters: seq[Future[void].Raising([CancelledError])]
+    putters: seq[Future[void].Raising([CancelledError])]
     queue: seq[T]
     maxsize: int
 
@@ -42,14 +42,14 @@ proc newAsyncHeapQueue*[T](
   ##
 
   AsyncHeapQueue[T](
-    getters: newSeq[Future[void]](),
-    putters: newSeq[Future[void]](),
+    getters: newSeq[Future[void].Raising([CancelledError])](),
+    putters: newSeq[Future[void].Raising([CancelledError])](),
     queue: newSeqOfCap[T](maxsize),
     maxsize: maxsize,
     queueType: queueType,
   )
 
-proc wakeupNext(waiters: var seq[Future[void]]) {.inline.} =
+proc wakeupNext(waiters: var seq[Future[void].Raising([CancelledError])]) {.inline.} =
   var i = 0
   while i < len(waiters):
     var waiter = waiters[i]
@@ -124,6 +124,11 @@ proc empty*[T](heap: AsyncHeapQueue[T]): bool {.inline.} =
   ## Return ``true`` if the queue is empty, ``false`` otherwise.
   (len(heap.queue) == 0)
 
+proc pushImpl[T](heap: AsyncHeapQueue[T], item: T) =
+  heap.queue.add(item)
+  siftdown(heap, 0, len(heap) - 1)
+  heap.getters.wakeupNext()
+
 proc pushNoWait*[T](heap: AsyncHeapQueue[T], item: T): Result[void, AsyncHQErrors] =
   ## Push `item` onto heap, maintaining the heap invariant.
   ##
@@ -131,28 +136,38 @@ proc pushNoWait*[T](heap: AsyncHeapQueue[T], item: T): Result[void, AsyncHQError
   if heap.full():
     return err(AsyncHQErrors.Full)
 
-  heap.queue.add(item)
-  siftdown(heap, 0, len(heap) - 1)
-  heap.getters.wakeupNext()
-
+  heap.pushImpl(item)
   return ok()
 
-proc push*[T](heap: AsyncHeapQueue[T], item: T) {.async, gcsafe.} =
+proc push*[T](
+    heap: AsyncHeapQueue[T], item: T
+) {.async: (raises: [CancelledError]), gcsafe.} =
   ## Push item into the queue, awaiting for an available slot
   ## when it's full
   ##
 
   while heap.full():
-    var putter = newFuture[void]("AsyncHeapQueue.push")
+    var putter = Future[void].Raising([CancelledError]).init("AsyncHeapQueue.push")
     heap.putters.add(putter)
     try:
       await putter
-    except CatchableError as exc:
+    except CancelledError as exc:
       if not (heap.full()) and not (putter.cancelled()):
         heap.putters.wakeupNext()
       raise exc
 
-  heap.pushNoWait(item).tryGet()
+  heap.pushImpl(item)
+
+proc popImpl[T](heap: AsyncHeapQueue[T]): T =
+  let lastelt = heap.queue.pop()
+  if heap.len > 0:
+    result = heap[0]
+    heap.queue[0] = lastelt
+    siftup(heap, 0)
+  else:
+    result = lastelt
+
+  heap.putters.wakeupNext()
 
 proc popNoWait*[T](heap: AsyncHeapQueue[T]): Result[T, AsyncHQErrors] =
   ## Pop and return the smallest item from `heap`,
@@ -162,30 +177,24 @@ proc popNoWait*[T](heap: AsyncHeapQueue[T]): Result[T, AsyncHQErrors] =
   if heap.empty():
     return err(AsyncHQErrors.Empty)
 
-  let lastelt = heap.queue.pop()
-  if heap.len > 0:
-    result = ok(heap[0])
-    heap.queue[0] = lastelt
-    siftup(heap, 0)
-  else:
-    result = ok(lastelt)
+  ok(heap.popImpl())
 
-  heap.putters.wakeupNext()
-
-proc pop*[T](heap: AsyncHeapQueue[T]): Future[T] {.async.} =
+proc pop*[T](
+    heap: AsyncHeapQueue[T]
+): Future[T] {.async: (raises: [CancelledError]), gcsafe.} =
   ## Remove and return an ``item`` from the beginning of the queue ``heap``.
   ## If the queue is empty, wait until an item is available.
   while heap.empty():
-    var getter = newFuture[void]("AsyncHeapQueue.pop")
+    var getter = Future[void].Raising([CancelledError]).init("AsyncHeapQueue.pop")
     heap.getters.add(getter)
     try:
       await getter
-    except CatchableError as exc:
+    except CancelledError as exc:
       if not (heap.empty()) and not (getter.cancelled()):
         heap.getters.wakeupNext()
       raise exc
 
-  return heap.popNoWait().tryGet()
+  heap.popImpl()
 
 proc del*[T](heap: AsyncHeapQueue[T], index: Natural) =
   ## Removes the element at `index` from `heap`,
@@ -195,10 +204,20 @@ proc del*[T](heap: AsyncHeapQueue[T], index: Natural) =
   if heap.empty():
     return
 
-  swap(heap.queue[^1], heap.queue[index])
-  let newLen = heap.len - 1
-  heap.queue.setLen(newLen)
-  if index < newLen:
+  let lastIdx = heap.len - 1
+  if index == lastIdx:
+    heap.queue.setLen(lastIdx)
+    heap.putters.wakeupNext()
+    return
+
+  let moved = heap.queue[lastIdx]
+  heap.queue.setLen(lastIdx)
+
+  let old = heap.queue[index]
+  heap.queue[index] = moved
+  if heapCmp(moved, old, heap.queueType == QueueType.Max):
+    heap.siftdown(0, index)
+  else:
     heap.siftup(index)
 
   heap.putters.wakeupNext()
@@ -218,12 +237,12 @@ proc update*[T](heap: AsyncHeapQueue[T], item: T): bool =
 
   let index = heap.find(item)
   if index > -1:
-    # replace item with new one in case it's a copy
+    let old = heap.queue[index]
     heap.queue[index] = item
-    # re-establish heap order
-    # TODO: don't start at 0 to avoid reshuffling
-    # entire heap
-    heap.siftup(0)
+    if heapCmp(item, old, heap.queueType == QueueType.Max):
+      siftdown(heap, 0, index)
+    else:
+      siftup(heap, index)
     return true
 
 proc pushOrUpdateNoWait*[T](
@@ -237,7 +256,9 @@ proc pushOrUpdateNoWait*[T](
 
   return heap.pushNoWait(item)
 
-proc pushOrUpdate*[T](heap: AsyncHeapQueue[T], item: T) {.async.} =
+proc pushOrUpdate*[T](
+    heap: AsyncHeapQueue[T], item: T
+) {.async: (raises: [CancelledError]), gcsafe.} =
   ## Update an item if it exists or push a new one
   ## awaiting until a slot becomes available
   ##
@@ -258,9 +279,9 @@ proc replace*[T](heap: AsyncHeapQueue[T], item: T): Result[T, AsyncHQErrors] =
   ##
 
   if heap.empty():
-    error(AsyncHQErrors.Empty)
+    return err(AsyncHQErrors.Empty)
 
-  result = heap[0]
+  result = ok(heap[0])
   heap.queue[0] = item
   siftup(heap, 0)
 
@@ -269,12 +290,14 @@ proc pushPopNoWait*[T](heap: AsyncHeapQueue[T], item: T): Result[T, AsyncHQError
   ##
 
   if heap.empty():
-    err(AsyncHQErrors.Empty)
+    return err(AsyncHQErrors.Empty)
 
-  if heap.len > 0 and heapCmp(heap[0], item, heap.queueType == QueueType.Max):
-    swap(item, heap[0])
+  var newItem = item
+  if heap.len > 0 and heapCmp(heap[0], newItem, heap.queueType == QueueType.Max):
+    swap(newItem, heap.queue[0])
     siftup(heap, 0)
-  return item
+
+  ok(newItem)
 
 proc clear*[T](heap: AsyncHeapQueue[T]) {.inline.} =
   ## Clears all elements of queue ``heap``.

--- a/tests/archivist/blockexchange/discovery/testdiscovery.nim
+++ b/tests/archivist/blockexchange/discovery/testdiscovery.nim
@@ -156,7 +156,9 @@ suite "Block Advertising and Discovery":
         for blk in blocks:
           {blk.address: Presence(address: blk.address)}
 
-    engine.peers.add(BlockExcPeerCtx(id: peerId, blocks: haves))
+    var peerCtx = BlockExcPeerCtx.new(peerId)
+    peerCtx.blocks = haves
+    engine.peers.add(peerCtx)
 
     blockDiscovery.findBlockProvidersHandler = proc(
         d: MockDiscovery, cid: Cid
@@ -164,7 +166,7 @@ suite "Block Advertising and Discovery":
       check false
 
     await engine.start()
-    engine.pendingBlocks.resolve(
+    await engine.pendingBlocks.resolve(
       blocks.mapIt(BlockDelivery(blk: it, address: it.address))
     )
 

--- a/tests/archivist/blockexchange/discovery/testdiscovery.nim
+++ b/tests/archivist/blockexchange/discovery/testdiscovery.nim
@@ -76,7 +76,7 @@ suite "Block Advertising and Discovery":
       minPeersPerBlock = 1,
     )
 
-    advertiser = Advertiser.new(localStore, blockDiscovery)
+    advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
     engine = BlockExcEngine.new(
       localStore, network, discovery, advertiser, peerStore, pendingBlocks
@@ -224,7 +224,7 @@ suite "E2E - Multiple Nodes Discovery":
           minPeersPerBlock = 1,
         )
 
-        advertiser = Advertiser.new(localStore, blockDiscovery)
+        advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
         engine = BlockExcEngine.new(
           localStore, network, discovery, advertiser, peerStore, pendingBlocks

--- a/tests/archivist/blockexchange/discovery/testdiscoveryengine.nim
+++ b/tests/archivist/blockexchange/discovery/testdiscoveryengine.nim
@@ -79,7 +79,7 @@ asyncchecksuite "Test Discovery Engine":
     blockDiscovery.findBlockProvidersHandler = proc(
         d: MockDiscovery, cid: Cid
     ): Future[seq[SignedPeerRecord]] {.async: (raises: [CancelledError]).} =
-      pendingBlocks.resolve(
+      await pendingBlocks.resolve(
         blocks.filterIt(it.cid == cid).mapIt(
           BlockDelivery(blk: it, address: it.address)
         )
@@ -142,7 +142,7 @@ asyncchecksuite "Test Discovery Engine":
       check cid in pendingCids
       pendingCids.keepItIf(it != cid)
       check peerStore.len < minPeers
-      var peerCtx = BlockExcPeerCtx(id: PeerId.example)
+      var peerCtx = BlockExcPeerCtx.new(PeerId.example)
 
       let address = BlockAddress(leaf: false, cid: cid)
 

--- a/tests/archivist/blockexchange/engine/testadvertiser.nim
+++ b/tests/archivist/blockexchange/engine/testadvertiser.nim
@@ -44,7 +44,7 @@ asyncchecksuite "Advertiser":
     ) {.async: (raises: [CancelledError]), gcsafe.} =
       advertised.add(cid)
 
-    advertiser = Advertiser.new(localStore, blockDiscovery)
+    advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
     await advertiser.start()
 
@@ -99,7 +99,7 @@ asyncchecksuite "Advertiser":
     (await newStore.putBlock(manifestBlk)).tryGet()
 
     await advertiser.stop()
-    advertiser = Advertiser.new(newStore, blockDiscovery)
+    advertiser = Advertiser.new(newStore, blockDiscovery, minAdvertisePeers = 0)
     await advertiser.start()
 
     check eventually manifestBlk.cid in advertised

--- a/tests/archivist/blockexchange/engine/testblockexc.nim
+++ b/tests/archivist/blockexchange/engine/testblockexc.nim
@@ -2,6 +2,7 @@ import std/sequtils
 import std/algorithm
 
 import pkg/chronos
+import pkg/taskpools
 import pkg/stew/byteutils
 
 import pkg/archivist/stores
@@ -157,13 +158,15 @@ asyncchecksuite "NetworkStore engine - 2 nodes":
 
 asyncchecksuite "NetworkStore - multiple nodes":
   var
+    cluster: NodesCluster
     nodes: seq[NodesComponents]
     blocks: seq[bt.Block]
     manifest0, manifest1, manifest2, manifest3: Manifest
 
   setup:
     blocks = (await makeRandomBlocks(datasetSize = 4096, blockSize = 256'nb)).tryGet
-    nodes = generateNodes(5)
+    cluster = generateNodes(5)
+    nodes = cluster.components
 
     # Store blocks as trees on each source node (4 blocks per node)
     manifest0 =
@@ -191,8 +194,12 @@ asyncchecksuite "NetworkStore - multiple nodes":
     await allFuturesThrowing(nodes.mapIt(it.switch.start()))
 
   teardown:
+    await allFuturesThrowing(nodes.mapIt(it.engine.stop()))
+    await allFuturesThrowing(nodes.mapIt(it.blockDiscovery.stop()))
     await allFuturesThrowing(nodes.mapIt(it.switch.stop()))
-
+    await allFuturesThrowing(nodes.mapIt(it.localStore.close()))
+    if not cluster.isNil and not cluster.taskpool.isNil:
+      cluster.taskpool.shutdown()
     nodes = @[]
 
   test "Should receive blocks for own want list":

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -868,11 +868,13 @@ asyncchecksuite "Block Download":
 
     await wantHaveSent.wait().wait(100.millis)
     check engine.pendingBlocks.retries(address) == retriesBefore
-    # No-spin guarantee: address was not immediately requeued after no-peer path
+    check engine.pendingBlocks.isDiscoveryWaiting(address)
     check not engine.pendingBlocks.isQueued(address)
+    check not engine.pendingBlocks.isScheduled(address)
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )
+    check not engine.pendingBlocks.isDiscoveryWaiting(address)
 
     await wantBlockSent.wait().wait(1.seconds)
     check address in engine.pendingBlocks

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -23,6 +23,17 @@ import pkg/archivist/utils/asyncheapqueue
 import ../../../asynctest
 import ../../helpers
 
+const NopSendWantListProc = proc(
+    id: PeerId,
+    addresses: seq[BlockAddress],
+    priority: int32 = 0,
+    cancel: bool = false,
+    wantType: WantType = WantType.WantHave,
+    full: bool = false,
+    sendDontHave: bool = false,
+) {.async: (raises: [CancelledError]).} =
+  discard
+
 const NopSendWantCancellationsProc = proc(
     id: PeerId, addresses: seq[BlockAddress]
 ) {.async: (raises: [CancelledError]).} =
@@ -426,7 +437,12 @@ asyncchecksuite "Block Download":
       SQLiteKVStore.new(SqliteMemory, tp).tryGet(),
       SQLiteKVStore.new(SqliteMemory, tp).tryGet(),
     )
-    network = BlockExcNetwork()
+    network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: NopSendWantListProc,
+        sendWantCancellations: NopSendWantCancellationsProc,
+      )
+    )
 
     discovery = DiscoveryEngine.new(
       localStore,
@@ -598,6 +614,130 @@ asyncchecksuite "Block Download":
 
     check wantBlockBatches == @[@[firstAddress], @[secondAddress]]
 
+  test "Should batch by peer before splitting want block requests":
+    let
+      peer2Key = PrivateKey.random(rng[]).tryGet()
+      peer2Id = PeerId.init(peer2Key.getPublicKey().tryGet()).tryGet()
+      peer2Ctx = BlockExcPeerCtx(id: peer2Id)
+      requestCount = DefaultWantBlockBatchSize * 4
+      addresses =
+        toSeq(0 ..< requestCount).mapIt(BlockAddress.init(blocks[0].cid, Natural(it)))
+      done = newAsyncEvent()
+
+    var
+      sentAddresses = initHashSet[BlockAddress]()
+      expectedPeer1 = initHashSet[BlockAddress]()
+      expectedPeer2 = initHashSet[BlockAddress]()
+      wantBlockBatches: seq[tuple[peer: PeerId, addresses: seq[BlockAddress]]]
+
+    proc sendWantList(
+        id: PeerId,
+        requestedAddresses: seq[BlockAddress],
+        priority: int32 = 0,
+        cancel: bool = false,
+        wantType: WantType = WantType.WantHave,
+        full: bool = false,
+        sendDontHave: bool = false,
+    ) {.async: (raises: [CancelledError]).} =
+      if wantType == WantBlock:
+        wantBlockBatches.add((peer: id, addresses: requestedAddresses))
+        for address in requestedAddresses:
+          sentAddresses.incl(address)
+        if sentAddresses.len == requestCount and not done.isSet:
+          done.fire()
+
+    engine.peers.add(peer2Ctx)
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
+      )
+    )
+
+    for i, address in addresses:
+      if i mod 2 == 0:
+        expectedPeer1.incl(address)
+        peerCtx.setPresence(Presence(address: address, have: true))
+      else:
+        expectedPeer2.incl(address)
+        peer2Ctx.setPresence(Presence(address: address, have: true))
+
+    let pendingHandles = engine.requestDeliveries(addresses).tryGet()
+    check pendingHandles.len == requestCount
+    await done.wait().wait(1.seconds)
+
+    let
+      peer1Batches = wantBlockBatches.filterIt(it.peer == peerId)
+      peer2Batches = wantBlockBatches.filterIt(it.peer == peer2Id)
+
+    var
+      peer1Sent = initHashSet[BlockAddress]()
+      peer2Sent = initHashSet[BlockAddress]()
+
+    for batch in peer1Batches:
+      for address in batch.addresses:
+        peer1Sent.incl(address)
+
+    for batch in peer2Batches:
+      for address in batch.addresses:
+        peer2Sent.incl(address)
+
+    check:
+      pendingHandles.len == requestCount
+      sentAddresses == addresses.toHashSet
+      peer1Batches.len == 2
+      peer2Batches.len == 2
+      peer1Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
+      peer2Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
+      peer1Sent == expectedPeer1
+      peer2Sent == expectedPeer2
+      sentAddresses.len == requestCount
+
+  test "Should dispatch timed-out batch for correct peer":
+    let
+      firstAddress = BlockAddress.init(blocks[0].cid)
+      secondAddress = BlockAddress.init(blocks[2].cid)
+      done = newAsyncEvent()
+
+    var dispatchedBatches: seq[tuple[peer: PeerId, addresses: seq[BlockAddress]]]
+
+    proc sendWantList(
+        id: PeerId,
+        addresses: seq[BlockAddress],
+        priority: int32 = 0,
+        cancel: bool = false,
+        wantType: WantType = WantType.WantHave,
+        full: bool = false,
+        sendDontHave: bool = false,
+    ) {.async: (raises: [CancelledError]).} =
+      if wantType == WantBlock:
+        dispatchedBatches.add((peer: id, addresses: addresses))
+        if not done.isSet:
+          done.fire()
+
+    engine.network = BlockExcNetwork(
+      request: BlockExcRequest(
+        sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
+      )
+    )
+    peerCtx.setPresence(Presence(address: firstAddress, have: true))
+    peerCtx.setPresence(Presence(address: secondAddress, have: true))
+
+    check:
+      engine.requestDelivery(firstAddress).isOk
+      engine.requestDelivery(secondAddress).isOk
+
+    await done.wait().wait(100.millis)
+
+    check:
+      dispatchedBatches.len == 1
+      dispatchedBatches[0].peer == peerId
+      dispatchedBatches[0].addresses.len == 2
+      firstAddress in dispatchedBatches[0].addresses
+      secondAddress in dispatchedBatches[0].addresses
+
+    await engine.completeBlock(firstAddress, blocks[0])
+    await engine.completeBlock(secondAddress, blocks[2])
+
   test "Should keep same peer request after clearing previous request":
     let
       address = BlockAddress.init(blocks[0].cid)
@@ -655,6 +795,8 @@ asyncchecksuite "Block Download":
     ) {.async: (raises: [CancelledError]).} =
       if wantType == WantBlock:
         check addresses == @[address]
+        check engine.pendingBlocks.isRequested(address)
+        check not engine.pendingBlocks.isScheduled(address)
         sent.complete()
 
     engine.network = BlockExcNetwork(
@@ -675,7 +817,7 @@ asyncchecksuite "Block Download":
     check engine.pendingBlocks.retries(address) == retriesBefore
 
     discard await engine.requestQueue.get()
-    await engine.sendRequestBatch(@[address])
+    await engine.sendRequestBatch(peerId, @[address])
     await sent.wait(100.millis)
 
     check engine.pendingBlocks.isRequested(address)
@@ -722,8 +864,12 @@ asyncchecksuite "Block Download":
     )
 
     let pending = engine.requestDelivery(address).tryGet()
+    let retriesBefore = engine.pendingBlocks.retries(address)
 
     await wantHaveSent.wait().wait(100.millis)
+    check engine.pendingBlocks.retries(address) == retriesBefore
+    # No-spin guarantee: address was not immediately requeued after no-peer path
+    check address notin engine.requestQueue
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )
@@ -732,6 +878,7 @@ asyncchecksuite "Block Download":
     check address in engine.pendingBlocks
     check engine.pendingBlocks.isRequested(address)
     check not engine.pendingBlocks.isScheduled(address)
+    check engine.pendingBlocks.retries(address) == retriesBefore - 1
     check address in peerCtx.blocksRequested
     await pending.cancelAndWait()
     expect CancelledError:

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -1,6 +1,7 @@
 import std/sequtils
 import std/algorithm
 import std/sets
+import std/importutils
 
 import pkg/chronos
 import pkg/libp2p/routing_record
@@ -13,6 +14,7 @@ import pkg/taskpools
 import pkg/archivist/rng
 import pkg/archivist/blockexchange
 import pkg/archivist/blockexchange/engine/engine {.all.}
+import pkg/archivist/blockexchange/engine/pendingblocks {.all.}
 import pkg/archivist/stores
 import pkg/archivist/chunker
 import pkg/archivist/discovery
@@ -22,6 +24,8 @@ import pkg/archivist/merkletree
 import pkg/archivist/utils/asyncheapqueue
 import ../../../asynctest
 import ../../helpers
+
+privateAccess(PendingBlocksManager)
 
 const NopSendWantListProc = proc(
     id: PeerId,
@@ -174,7 +178,7 @@ asyncchecksuite "NetworkStore engine handlers":
       localStore, network, discovery, advertiser, peerStore, pendingBlocks
     )
 
-    peerCtx = BlockExcPeerCtx(id: peerId)
+    peerCtx = BlockExcPeerCtx.new(peerId)
     engine.peers.add(peerCtx)
 
   teardown:
@@ -334,7 +338,7 @@ asyncchecksuite "NetworkStore engine handlers":
         full: bool = false,
         sendDontHave: bool = false,
     ) {.async: (raises: [CancelledError]).} =
-      engine.pendingBlocks.resolve(
+      await engine.pendingBlocks.resolve(
         blocks.filterIt(it.address in addresses).mapIt(
           BlockDelivery(blk: it, address: it.address)
         )
@@ -386,11 +390,11 @@ asyncchecksuite "NetworkStore engine handlers":
       request: BlockExcRequest(sendWantCancellations: sendWantCancellations)
     )
 
-    let otherPeerCtx = BlockExcPeerCtx(id: otherPeerId)
+    let otherPeerCtx = BlockExcPeerCtx.new(otherPeerId)
     engine.peers.add(otherPeerCtx)
 
     for delivery in blocksDelivery:
-      peerCtx.blocksRequested.incl(delivery.address)
+      discard engine.pendingBlocks.markRequested(delivery.address, peerCtx, 60.seconds)
       otherPeerCtx.blocksRequested.incl(delivery.address)
 
     await engine.blocksDeliveryHandler(peerId, blocksDelivery)
@@ -459,7 +463,7 @@ asyncchecksuite "Block Download":
       localStore, network, discovery, advertiser, peerStore, pendingBlocks
     )
 
-    peerCtx = BlockExcPeerCtx(id: peerId)
+    peerCtx = BlockExcPeerCtx.new(peerId)
     engine.peers.add(peerCtx)
     await engine.start()
 
@@ -470,11 +474,11 @@ asyncchecksuite "Block Download":
   test "Should fail exhausted requests before queueing":
     let address = BlockAddress.init(blocks[0].cid)
 
-    engine.pendingBlocks.blockRetries = 0
+    engine.pendingBlocks.retries = 0
 
     let pending = engine.requestDelivery(address).tryGet()
 
-    check not engine.pendingBlocks.isQueued(address)
+    check address in engine.pendingBlocks
     expect RetriesExhaustedEngineError:
       discard await pending
 
@@ -523,7 +527,7 @@ asyncchecksuite "Block Download":
       address2 = BlockAddress.init(blocks[1].cid)
       handles = (engine.requestDeliveries(@[address1, address2])).tryGet()
 
-    engine.pendingBlocks.failWantHandle(
+    await engine.pendingBlocks.failWantHandle(
       address1, QueueFailedEngineError, "Block request queue failed"
     )
     await engine.completeBlock(address2, blocks[1])
@@ -610,7 +614,7 @@ asyncchecksuite "Block Download":
 
     discard engine.requestDelivery(firstAddress).tryGet()
 
-    await secondSent.wait().wait(100.millis)
+    await secondSent.wait().wait(250.millis)
 
     check wantBlockBatches == @[@[firstAddress], @[secondAddress]]
 
@@ -618,7 +622,7 @@ asyncchecksuite "Block Download":
     let
       peer2Key = PrivateKey.random(rng[]).tryGet()
       peer2Id = PeerId.init(peer2Key.getPublicKey().tryGet()).tryGet()
-      peer2Ctx = BlockExcPeerCtx(id: peer2Id)
+      peer2Ctx = BlockExcPeerCtx.new(peer2Id)
       requestCount = DefaultWantBlockBatchSize * 4
       addresses =
         toSeq(0 ..< requestCount).mapIt(BlockAddress.init(blocks[0].cid, Natural(it)))
@@ -757,7 +761,7 @@ asyncchecksuite "Block Download":
 
     peerCtx.activityTimeout = 20.millis
     peerCtx.setPresence(Presence(address: address, have: true))
-    engine.pendingBlocks.blockRetries = 3
+    engine.pendingBlocks.retries = 3
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
@@ -768,17 +772,14 @@ asyncchecksuite "Block Download":
     await sent.wait(100.millis)
 
     let retriesBefore = engine.pendingBlocks.retries(address)
-    await engine.pendingBlocks.clearRequest(address, peerId)
-    peerCtx.blockRequestCancelled(address)
-    let nextRequestId = engine.pendingBlocks.markRequested(address, peerId)
-    check nextRequestId.isSome
-    peerCtx.blockRequestScheduled(address)
-
-    await sleepAsync(50.millis)
-
+    await engine.pendingBlocks.clearRequest(address, peerCtx)
+    let nextRequestId = engine.pendingBlocks.markRequested(address, peerCtx)
+    check nextRequestId != nil
     check engine.pendingBlocks.isRequested(address)
     check engine.pendingBlocks.getRequestPeer(address) == peerId.some
-    check engine.pendingBlocks.retries(address) == retriesBefore
+    # markRequested decrements retries internally now
+    # markRequested decrements retries internally now
+    check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
   test "Should gate queued sends and decrement on send":
     let address = BlockAddress.init(blocks[0].cid)
@@ -796,7 +797,6 @@ asyncchecksuite "Block Download":
       if wantType == WantBlock:
         check addresses == @[address]
         check engine.pendingBlocks.isRequested(address)
-        check not engine.pendingBlocks.isScheduled(address)
         sent.complete()
 
     engine.network = BlockExcNetwork(
@@ -808,23 +808,15 @@ asyncchecksuite "Block Download":
 
     let pending = engine.requestDelivery(address).tryGet()
     let retriesBefore = engine.pendingBlocks.retries(address)
-    check engine.pendingBlocks.isQueued(address)
-    check engine.pendingBlocks.readyQueue.len == 1
 
-    engine.scheduleBlockSend(address)
-    check engine.pendingBlocks.isQueued(address)
-    check engine.pendingBlocks.readyQueue.len == 1
-    check engine.pendingBlocks.retries(address) == retriesBefore
-
-    discard await engine.pendingBlocks.dequeue()
-    await engine.sendRequestBatch(peerId, @[address])
     await sent.wait(100.millis)
 
     check engine.pendingBlocks.isRequested(address)
+    # markRequested decrements retries internally now
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
-    engine.scheduleBlockSend(address)
-    check not engine.pendingBlocks.isQueued(address)
+    await engine.pendingBlocks.retryAddresses(@[address], DefaultBlockSendRetryDelay)
+    # markRequested decrements retries internally now
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
     await engine.completeBlock(address, blocks[0])
@@ -867,19 +859,18 @@ asyncchecksuite "Block Download":
     let retriesBefore = engine.pendingBlocks.retries(address)
 
     await wantHaveSent.wait().wait(100.millis)
+    # Only WantHave sent so far -- markRequested not called yet
     check engine.pendingBlocks.retries(address) == retriesBefore
-    check engine.pendingBlocks.isDiscoveryWaiting(address)
-    check not engine.pendingBlocks.isQueued(address)
-    check not engine.pendingBlocks.isScheduled(address)
+    check address in engine.pendingBlocks
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )
-    check not engine.pendingBlocks.isDiscoveryWaiting(address)
+    check address in engine.pendingBlocks
 
     await wantBlockSent.wait().wait(1.seconds)
     check address in engine.pendingBlocks
     check engine.pendingBlocks.isRequested(address)
-    check not engine.pendingBlocks.isScheduled(address)
+    # markRequested decrements retries internally now
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
     check address in peerCtx.blocksRequested
     await pending.cancelAndWait()
@@ -910,7 +901,7 @@ asyncchecksuite "Block Download":
         check engine.pendingBlocks.retriesExhausted(address) == false
         steps.fire()
 
-    engine.pendingBlocks.blockRetries = 10
+    engine.pendingBlocks.retries = 10
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
@@ -945,7 +936,7 @@ asyncchecksuite "Block Download":
     ) {.async: (raises: [CancelledError]).} =
       done.complete()
 
-    engine.pendingBlocks.blockRetries = 10
+    engine.pendingBlocks.retries = 10
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
@@ -977,7 +968,7 @@ asyncchecksuite "Block Download":
         check addresses == @[address]
         done.complete()
 
-    engine.pendingBlocks.blockRetries = 10
+    engine.pendingBlocks.retries = 10
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
@@ -1012,7 +1003,7 @@ asyncchecksuite "Block Download":
       if wantType == WantBlock:
         done.complete()
 
-    engine.pendingBlocks.blockRetries = 10
+    engine.pendingBlocks.retries = 10
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: NopSendWantCancellationsProc
@@ -1061,7 +1052,7 @@ asyncchecksuite "Block Download":
     ) {.async: (raises: [CancelledError]).} =
       raise newException(CancelledError, "cancelled cancellation send")
 
-    engine.pendingBlocks.blockRetries = 10
+    engine.pendingBlocks.retries = 10
     engine.network = BlockExcNetwork(
       request: BlockExcRequest(
         sendWantList: sendWantList, sendWantCancellations: sendWantCancellations
@@ -1140,7 +1131,7 @@ asyncchecksuite "Task Handler":
       let seckey = PrivateKey.random(rng[]).tryGet()
       peers.add(PeerId.init(seckey.getPublicKey().tryGet()).tryGet())
 
-      peersCtx.add(BlockExcPeerCtx(id: peers[i]))
+      peersCtx.add(BlockExcPeerCtx.new(peers[i]))
       peerStore.add(peersCtx[i])
 
   teardown:

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -474,7 +474,7 @@ asyncchecksuite "Block Download":
 
     let pending = engine.requestDelivery(address).tryGet()
 
-    check address notin engine.requestQueue
+    check not engine.pendingBlocks.isQueued(address)
     expect RetriesExhaustedEngineError:
       discard await pending
 
@@ -808,15 +808,15 @@ asyncchecksuite "Block Download":
 
     let pending = engine.requestDelivery(address).tryGet()
     let retriesBefore = engine.pendingBlocks.retries(address)
-    check address in engine.requestQueue
-    check engine.requestQueue.len == 1
+    check engine.pendingBlocks.isQueued(address)
+    check engine.pendingBlocks.readyQueue.len == 1
 
     engine.scheduleBlockSend(address)
-    check address in engine.requestQueue
-    check engine.requestQueue.len == 1
+    check engine.pendingBlocks.isQueued(address)
+    check engine.pendingBlocks.readyQueue.len == 1
     check engine.pendingBlocks.retries(address) == retriesBefore
 
-    discard await engine.requestQueue.get()
+    discard await engine.pendingBlocks.dequeue()
     await engine.sendRequestBatch(peerId, @[address])
     await sent.wait(100.millis)
 
@@ -824,7 +824,7 @@ asyncchecksuite "Block Download":
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
     engine.scheduleBlockSend(address)
-    check address notin engine.requestQueue
+    check not engine.pendingBlocks.isQueued(address)
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
     await engine.completeBlock(address, blocks[0])
@@ -869,7 +869,7 @@ asyncchecksuite "Block Download":
     await wantHaveSent.wait().wait(100.millis)
     check engine.pendingBlocks.retries(address) == retriesBefore
     # No-spin guarantee: address was not immediately requeued after no-peer path
-    check address notin engine.requestQueue
+    check not engine.pendingBlocks.isQueued(address)
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -394,7 +394,7 @@ asyncchecksuite "NetworkStore engine handlers":
     engine.peers.add(otherPeerCtx)
 
     for delivery in blocksDelivery:
-      discard engine.pendingBlocks.markRequested(delivery.address, peerCtx, 60.seconds)
+      engine.pendingBlocks.markRequested(delivery.address, peerCtx, 60.seconds)
       otherPeerCtx.blocksRequested.incl(delivery.address)
 
     await engine.blocksDeliveryHandler(peerId, blocksDelivery)
@@ -773,11 +773,9 @@ asyncchecksuite "Block Download":
 
     let retriesBefore = engine.pendingBlocks.retries(address)
     await engine.pendingBlocks.clearRequest(address, peerCtx)
-    let nextRequestId = engine.pendingBlocks.markRequested(address, peerCtx)
-    check nextRequestId != nil
+    engine.pendingBlocks.markRequested(address, peerCtx)
     check engine.pendingBlocks.isRequested(address)
     check engine.pendingBlocks.getRequestPeer(address) == peerId.some
-    # markRequested decrements retries internally now
     # markRequested decrements retries internally now
     check engine.pendingBlocks.retries(address) == retriesBefore - 1
 
@@ -807,17 +805,19 @@ asyncchecksuite "Block Download":
     peerCtx.setPresence(Presence(address: address, have: true))
 
     let pending = engine.requestDelivery(address).tryGet()
-    let retriesBefore = engine.pendingBlocks.retries(address)
 
-    await sent.wait(100.millis)
-
+    # Wait for the WantBlock send (event-driven, not timeout-based)
+    await sent.wait(1.seconds)
     check engine.pendingBlocks.isRequested(address)
-    # markRequested decrements retries internally now
-    check engine.pendingBlocks.retries(address) == retriesBefore - 1
+    check address in peerCtx.blocksRequested
+    let actualRetries = engine.pendingBlocks.retries(address)
+    check actualRetries == DefaultBlockRetries - 1
 
+    # retryAddresses requeues the block but does not decrement retries itself
     await engine.pendingBlocks.retryAddresses(@[address], DefaultBlockSendRetryDelay)
-    # markRequested decrements retries internally now
-    check engine.pendingBlocks.retries(address) == retriesBefore - 1
+    check address in engine.pendingBlocks
+    # Retries unchanged - retryAddresses does not call markRequested
+    check engine.pendingBlocks.retries(address) == DefaultBlockRetries - 1
 
     await engine.completeBlock(address, blocks[0])
     check (await pending).blk == blocks[0]
@@ -856,23 +856,24 @@ asyncchecksuite "Block Download":
     )
 
     let pending = engine.requestDelivery(address).tryGet()
-    let retriesBefore = engine.pendingBlocks.retries(address)
 
-    await wantHaveSent.wait().wait(100.millis)
-    # Only WantHave sent so far -- markRequested not called yet
-    check engine.pendingBlocks.retries(address) == retriesBefore
+    # Wait for WantHave (event-driven)
+    await wantHaveSent.wait().wait(1.seconds)
+    # Only WantHave sent so far - markRequested not called yet
+    check engine.pendingBlocks.retries(address) == DefaultBlockRetries
     check address in engine.pendingBlocks
+
     await engine.blockPresenceHandler(
       peerId, @[BlockPresence(address: address, `type`: BlockPresenceType.Have)]
     )
     check address in engine.pendingBlocks
 
+    # Wait for WantBlock (event-driven)
     await wantBlockSent.wait().wait(1.seconds)
     check address in engine.pendingBlocks
     check engine.pendingBlocks.isRequested(address)
-    # markRequested decrements retries internally now
-    check engine.pendingBlocks.retries(address) == retriesBefore - 1
     check address in peerCtx.blocksRequested
+    check engine.pendingBlocks.retries(address) == DefaultBlockRetries - 1
     await pending.cancelAndWait()
     expect CancelledError:
       discard await pending

--- a/tests/archivist/blockexchange/engine/testengine.nim
+++ b/tests/archivist/blockexchange/engine/testengine.nim
@@ -618,7 +618,7 @@ asyncchecksuite "Block Download":
 
     check wantBlockBatches == @[@[firstAddress], @[secondAddress]]
 
-  test "Should batch by peer before splitting want block requests":
+  test "Send all blocks to all peers":
     let
       peer2Key = PrivateKey.random(rng[]).tryGet()
       peer2Id = PeerId.init(peer2Key.getPublicKey().tryGet()).tryGet()
@@ -630,9 +630,7 @@ asyncchecksuite "Block Download":
 
     var
       sentAddresses = initHashSet[BlockAddress]()
-      expectedPeer1 = initHashSet[BlockAddress]()
-      expectedPeer2 = initHashSet[BlockAddress]()
-      wantBlockBatches: seq[tuple[peer: PeerId, addresses: seq[BlockAddress]]]
+      wantBlockBatches: Table[PeerId, seq[BlockAddress]]
 
     proc sendWantList(
         id: PeerId,
@@ -644,9 +642,9 @@ asyncchecksuite "Block Download":
         sendDontHave: bool = false,
     ) {.async: (raises: [CancelledError]).} =
       if wantType == WantBlock:
-        wantBlockBatches.add((peer: id, addresses: requestedAddresses))
-        for address in requestedAddresses:
-          sentAddresses.incl(address)
+        wantBlockBatches.mgetOrPut(id, @[]).add(requestedAddresses)
+        sentAddresses.incl(requestedAddresses.toHashSet)
+
         if sentAddresses.len == requestCount and not done.isSet:
           done.fire()
 
@@ -659,42 +657,18 @@ asyncchecksuite "Block Download":
 
     for i, address in addresses:
       if i mod 2 == 0:
-        expectedPeer1.incl(address)
         peerCtx.setPresence(Presence(address: address, have: true))
       else:
-        expectedPeer2.incl(address)
         peer2Ctx.setPresence(Presence(address: address, have: true))
 
     let pendingHandles = engine.requestDeliveries(addresses).tryGet()
     check pendingHandles.len == requestCount
     await done.wait().wait(1.seconds)
 
-    let
-      peer1Batches = wantBlockBatches.filterIt(it.peer == peerId)
-      peer2Batches = wantBlockBatches.filterIt(it.peer == peer2Id)
-
-    var
-      peer1Sent = initHashSet[BlockAddress]()
-      peer2Sent = initHashSet[BlockAddress]()
-
-    for batch in peer1Batches:
-      for address in batch.addresses:
-        peer1Sent.incl(address)
-
-    for batch in peer2Batches:
-      for address in batch.addresses:
-        peer2Sent.incl(address)
-
     check:
-      pendingHandles.len == requestCount
       sentAddresses == addresses.toHashSet
-      peer1Batches.len == 2
-      peer2Batches.len == 2
-      peer1Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
-      peer2Batches.allIt(it.addresses.len == DefaultWantBlockBatchSize)
-      peer1Sent == expectedPeer1
-      peer2Sent == expectedPeer2
-      sentAddresses.len == requestCount
+      wantBlockBatches[peerCtx.id].len == requestCount div 2
+      wantBlockBatches[peer2Ctx.id].len == requestCount div 2
 
   test "Should dispatch timed-out batch for correct peer":
     let

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -487,18 +487,14 @@ suite "PendingBlocks ownership model":
 
   test "Generation staleness skips stale heap entries":
     let
-      pb = PendingBlocksManager.new()
+      pb = PendingBlocksManager.new(batchDeadline = 50.millis)
       peerCtx = makePeerCtx(makePeerId())
 
-    var called = 0
+    var callCount = 0
     pb.sendBatch = proc(
         peer: BlockExcPeerCtx, batch: seq[BlockAddress]
     ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
-      called.inc()
-      check called == 1
-      check batch.len == 1
-      check batch[0]
-
+      callCount.inc()
       success()
 
     pb.getPeerForBlock = proc(
@@ -506,34 +502,36 @@ suite "PendingBlocks ownership model":
     ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
       success peerCtx
 
+    # First getWantHandle: creates BlockReq (generation=0), pushes BlockItem(gen=0)
+    discard pb.getWantHandle(address)
+    # Second getWantHandle: addOwner increments generation to 1, pushes BlockItem(gen=1)
+    discard pb.getWantHandle(address)
+
     await pb.start()
-
-    # Request the same address twice to create multiple heap entries
-    let
-      handle1 = pb.getWantHandle(address)
-      handle2 = pb.getWantHandle(address)
-
-    await sleepAsync(500.millis)
+    # batchDeadline (50ms) + buffer — worker dispatches after deadline expires
+    await sleepAsync(100.millis)
     await pb.stop()
 
-    # Should only be sent once (stale entry skipped)
-    check sentAddresses.len == 1
-    check sentAddresses[0] == address
+    # Only the fresh entry (gen=1) was dispatched; stale gen=0 was skipped
+    check callCount == 1
 
   test "validateBlock rejects missing block":
-    # validateBlock is internal, tested indirectly through pushPeerBlock
-    # If a block is removed from self.blocks after being pushed to the pipe,
-    # the batch worker should skip it
+    # validateBlock is internal to peerBatchWorker. If a block is pushed to
+    # the pipe but never added to self.blocks, the worker should skip it
+    # and not call sendBatch.
     let
       pb = PendingBlocksManager.new()
       peerCtx = makePeerCtx(makePeerId())
-      otherAddr = BlockAddress.init(bt.Block.new("other".toBytes).tryGet.cid)
+      missingAddr = BlockAddress.init(bt.Block.new("missing".toBytes).tryGet.cid)
+      firstBatchSent = newAsyncEvent()
 
     var sentAddresses: seq[BlockAddress]
     pb.sendBatch = proc(
         peer: BlockExcPeerCtx, batch: seq[BlockAddress]
     ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
-      sentAddresses.add(batch[0])
+      for a in batch:
+        sentAddresses.add(a)
+      firstBatchSent.fire()
       success()
 
     pb.getPeerForBlock = proc(
@@ -543,44 +541,18 @@ suite "PendingBlocks ownership model":
 
     await pb.start()
 
-    # Request a block
+    # Request a valid block to create a BatchReq in byPeer
     let h = pb.getWantHandle(address)
+    await firstBatchSent.wait()
 
-    # Wait for it to be sent
-    await sleepAsync(500.millis)
+    # Push a missing address directly to the peer pipe (never in self.blocks)
+    let pipe = pb.byPeer[peerCtx.id].pipe
+    await pipe.put(missingAddr)
+
+    # Give the worker time to pick it up and reject it
+    await sleepAsync(200.millis)
     await pb.stop()
 
-    # The block should have been sent
+    # Only the valid block should have been sent; missingAddr was rejected
     check sentAddresses.len == 1
     check sentAddresses[0] == address
-
-  test "stop drains queued pipe items":
-    let
-      pb = PendingBlocksManager.new()
-      peerCtx = makePeerCtx(makePeerId())
-
-    # Block sendBatch so the batch worker stays stuck
-    pb.sendBatch = proc(
-        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
-    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
-      await sleepAsync(10.hours)
-      success()
-
-    pb.getPeerForBlock = proc(
-        address: BlockAddress
-    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
-      success peerCtx
-
-    await pb.start()
-
-    # Request a block - it will go to the pipe, batch worker will get stuck in sendBatch
-    discard pb.getWantHandle(address)
-
-    # Wait for the block to reach the batch worker
-    await sleepAsync(200.millis)
-
-    # Stop should cancel the batch worker (tracked futures) and return cleanly
-    await pb.stop()
-
-    # If stop completes without hanging, the drain worked correctly
-    check true

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -91,6 +91,7 @@ suite "Pending Blocks":
       blks = (0 .. 9).mapIt(bt.Block.new(("Hello " & $it).toBytes).tryGet)
       handles = blks.mapIt(pendingBlocks.getWantHandle(it.cid))
 
+    pendingBlocks.running = true
     await pendingBlocks.stop()
 
     check pendingBlocks.len == 0

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -19,6 +19,8 @@ import ../../asynctest
 
 privateAccess(PendingBlocksManager)
 privateAccess(BatchReq)
+privateAccess(BlockItem)
+privateAccess(BlockReq)
 
 proc makePeerId(): PeerId =
   let seckey = PrivateKey.random(Rng.instance()[]).tryGet()
@@ -556,3 +558,70 @@ suite "PendingBlocks ownership model":
     # Only the valid block should have been sent; missingAddr was rejected
     check sentAddresses.len == 1
     check sentAddresses[0] == address
+
+  test "Deadline expiry does not lose queued blocks":
+    let
+      pb = PendingBlocksManager.new(batchDeadline = 1.millis)
+      peerCtx = makePeerCtx(makePeerId())
+
+    var sent: seq[BlockAddress]
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      for a in batch:
+        sent.add(a)
+      success()
+
+    pb.getPeerForBlock = proc(
+        a: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    await pb.start()
+
+    # Push first block — creates BatchReq, worker starts collecting
+    discard pb.getWantHandle(address)
+    # Give the worker time to start the batch and have the deadline fire
+    await sleepAsync(10.millis)
+
+    # Push second block — should be picked up by next batch iteration
+    let address2 = BlockAddress.init(blk.cid, Natural(1))
+    discard pb.getWantHandle(address2)
+    await sleepAsync(100.millis)
+    await pb.stop()
+
+    check sent.len == 2
+    check sent[0] == address
+    check sent[1] == address2
+
+  test "Batch requeued on collection exception":
+    var
+      pb = PendingBlocksManager.new(
+        batchSize = 2, batchDeadline = 5.minutes, blockSendTimeout = 5.minutes
+      )
+      peerCtx = makePeerCtx(makePeerId())
+
+    let batchReq = BatchReq(peer: peerCtx, pipe: newAsyncQueue[BlockAddress](2))
+    pb.byPeer[peerCtx.id] = batchReq
+
+    pb.running = true
+    discard pb.getWantHandle(address)
+    check pb.blockQueue.len == 1
+    batchReq.workerFut = pb.peerBatchWorker(batchReq)
+    discard pb.blockQueue.pop()
+    await batchReq.pipe.put(address)
+    check eventually(batchReq.pipe.empty())
+
+    # Cancel worker fut while it waits in `await next or batchReq.deadline`.
+    # The inner `except CatchableError` should requeue the partial batch.
+    await batchReq.workerFut.cancelAndWait()
+
+    check pb.blockQueue.len == 1
+    check pb.blockQueue[0].address == address
+    check pb.blockQueue[0].generation == 2
+
+    check address in pb.blocks
+    check pb.blocks[address].state == Pending
+    check pb.blocks[address].requestedPeer.isNil
+
+    await pb.stop()

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -1,13 +1,16 @@
 import std/sequtils
 import std/algorithm
+import std/heapqueue
 
 import pkg/chronos
 import pkg/libp2p
 import pkg/stew/byteutils
+import pkg/questionable
 
 import pkg/archivist/rng
 import pkg/archivist/blocktype as bt
 import pkg/archivist/blockexchange
+import pkg/archivist/utils/trackedfutures
 
 import ../helpers
 import ../../asynctest
@@ -15,6 +18,9 @@ import ../../asynctest
 proc makePeerId(): PeerId =
   let seckey = PrivateKey.random(Rng.instance()[]).tryGet()
   PeerId.init(seckey.getPublicKey().tryGet()).tryGet()
+
+proc makePeerCtx(id: PeerId): BlockExcPeerCtx =
+  BlockExcPeerCtx.new(id)
 
 suite "Pending Blocks":
   test "Should add want handle":
@@ -33,7 +39,9 @@ suite "Pending Blocks":
       handle = pendingBlocks.getWantHandle(blk.cid)
 
     check blk.cid in pendingBlocks
-    pendingBlocks.resolve(@[blk].mapIt(BlockDelivery(blk: it, address: it.address)))
+    await pendingBlocks.resolve(
+      @[blk].mapIt(BlockDelivery(blk: it, address: it.address))
+    )
     await sleepAsync(0.millis)
       # trigger the event loop, otherwise the block finishes before poll runs
     let resolved = await handle
@@ -66,7 +74,7 @@ suite "Pending Blocks":
     check blk.cid in pendingBlocks
     check eventually pendingBlocks.owners(blk.cid) == 1
 
-    pendingBlocks.resolve(@[BlockDelivery(blk: blk, address: blk.address)])
+    await pendingBlocks.resolve(@[BlockDelivery(blk: blk, address: blk.address)])
     check (await handle2).blk == blk
 
   test "Should cancel all want handles":
@@ -75,7 +83,7 @@ suite "Pending Blocks":
       blks = (0 .. 9).mapIt(bt.Block.new(("Hello " & $it).toBytes).tryGet)
       handles = blks.mapIt(pendingBlocks.getWantHandle(it.cid))
 
-    await pendingBlocks.cancelAll()
+    await pendingBlocks.stop()
 
     check pendingBlocks.len == 0
     for handle in handles:
@@ -83,104 +91,116 @@ suite "Pending Blocks":
         discard await handle
 
   test "Should fire request timeout for current attempt":
+    var timedOut = false
     let
-      pendingBlocks = PendingBlocksManager.new()
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
-      peer = makePeerId()
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
 
-    var timedOut = false
-    pendingBlocks.onTimeout = proc(
-        timeoutAddress: BlockAddress, timeoutPeer: PeerId
-    ) {.gcsafe, async: (raises: []).} =
-      check timeoutAddress == address
-      check timeoutPeer == peer
-      timedOut = true
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        check timeoutAddress == address
+        check timeoutPeer == peerId
+        timedOut = true
+
+      pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peer, 1.millis).isSome
+    check pendingBlocks.markRequested(address, peerCtx, 1.millis) != nil
     check eventually timedOut
 
   test "Should cancel request timeout on clear":
+    var timedOut = false
     let
-      pendingBlocks = PendingBlocksManager.new()
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
-      peer = makePeerId()
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
 
-    var timedOut = false
-    pendingBlocks.onTimeout = proc(
-        timeoutAddress: BlockAddress, timeoutPeer: PeerId
-    ) {.gcsafe, async: (raises: []).} =
-      timedOut = true
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        timedOut = true
+
+      pendingBlocks = PendingBlocksManager.new()
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peer, 10.millis).isSome
-    await pendingBlocks.clearRequest(address, peer)
+    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
+    await pendingBlocks.clearRequest(address, peerCtx)
     await sleepAsync(50.millis)
     check not timedOut
 
   test "Should cancel request timeout on resolve":
+    var timedOut = false
     let
-      pendingBlocks = PendingBlocksManager.new()
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
-      peer = makePeerId()
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
 
-    var timedOut = false
-    pendingBlocks.onTimeout = proc(
-        timeoutAddress: BlockAddress, timeoutPeer: PeerId
-    ) {.gcsafe, async: (raises: []).} =
-      timedOut = true
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        timedOut = true
+
+      pendingBlocks = PendingBlocksManager.new()
 
     let handle = pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peer, 10.millis).isSome
-    pendingBlocks.resolve(@[BlockDelivery(blk: blk, address: blk.address)])
+    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
+    await pendingBlocks.resolve(@[BlockDelivery(blk: blk, address: blk.address)])
     check (await handle).blk == blk
     await sleepAsync(20.millis)
     check not timedOut
 
   test "Should cancel request timeout on final owner release":
+    var timedOut = false
     let
-      pendingBlocks = PendingBlocksManager.new()
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
-      peer = makePeerId()
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
 
-    var timedOut = false
-    pendingBlocks.onTimeout = proc(
-        timeoutAddress: BlockAddress, timeoutPeer: PeerId
-    ) {.gcsafe, async: (raises: []).} =
-      timedOut = true
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        timedOut = true
+
+      pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     let handle = pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peer, 10.millis).isSome
+    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
     await handle.cancelAndWait()
     check eventually blk.cid notin pendingBlocks
     await sleepAsync(20.millis)
     check not timedOut
 
   test "Should replace cleared request timeout with next attempt":
+    var timeouts: seq[PeerId]
+
     let
-      pendingBlocks = PendingBlocksManager.new()
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
-      firstPeer = makePeerId()
-      secondPeer = makePeerId()
+      firstPeerId = makePeerId()
+      firstPeerCtx = makePeerCtx(firstPeerId)
+      secondPeerId = makePeerId()
+      secondPeerCtx = makePeerCtx(secondPeerId)
 
-    var timeouts: seq[PeerId]
-    pendingBlocks.onTimeout = proc(
-        timeoutAddress: BlockAddress, timeoutPeer: PeerId
-    ) {.gcsafe, async: (raises: []).} =
-      check timeoutAddress == address
-      timeouts.add(timeoutPeer)
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        check timeoutAddress == address
+        timeouts.add(timeoutPeer)
+
+      pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, firstPeer, 20.millis).isSome
-    await pendingBlocks.clearRequest(address, firstPeer)
-    check pendingBlocks.markRequested(address, secondPeer, 1.millis).isSome
+    check pendingBlocks.markRequested(address, firstPeerCtx, 20.millis) != nil
+    await pendingBlocks.clearRequest(address, firstPeerCtx)
+    check pendingBlocks.markRequested(address, secondPeerCtx, 1.millis) != nil
     check eventually timeouts.len == 1
-    check timeouts[0] == secondPeer
+    check timeouts[0] == secondPeerId
     await sleepAsync(25.millis)
     check timeouts.len == 1
 
@@ -197,7 +217,7 @@ suite "Pending Blocks":
 
   test "Should handle retry counters":
     let
-      pendingBlocks = PendingBlocksManager.new(3)
+      pendingBlocks = PendingBlocksManager.new(retries = 3)
       blk = bt.Block.new("Hello".toBytes).tryGet
       address = BlockAddress.init(blk.cid)
       handle = pendingBlocks.getWantHandle(blk.cid)
@@ -210,3 +230,53 @@ suite "Pending Blocks":
     pendingBlocks.decRetries(address)
     check pendingBlocks.retries(address) == 0
     check pendingBlocks.retriesExhausted(address)
+
+suite "PendingBlocks ownership model":
+  let
+    blk = bt.Block.new("Hello".toBytes).tryGet
+    address = BlockAddress.init(blk.cid)
+
+  test "requeue pushes snapshot":
+    let pb = PendingBlocksManager.new()
+    discard pb.getWantHandle(address)
+    await pb.retryAddresses(@[address], 10.seconds)
+    check address in pb
+    check not pb.isRequested(address)
+
+  test "markRequested sets in-flight":
+    let pb = PendingBlocksManager.new()
+    discard pb.getWantHandle(address)
+    let retriesBefore = pb.retries(address)
+    let peerCtx = makePeerCtx(makePeerId())
+
+    discard pb.markRequested(address, peerCtx, 60.seconds)
+
+    check pb.isRequested(address)
+    # markRequested decrements retries internally now
+    check pb.retries(address) == retriesBefore - 1
+
+  test "clearRequest clears in-flight":
+    let pb = PendingBlocksManager.new()
+    discard pb.getWantHandle(address)
+    let peerCtx = makePeerCtx(makePeerId())
+    discard pb.markRequested(address, peerCtx, 60.seconds)
+    check pb.isRequested(address)
+
+    await pb.clearRequest(address, peerCtx)
+    check not pb.isRequested(address)
+
+  test "failWantHandle fails request":
+    let pb = PendingBlocksManager.new()
+    let handle = pb.getWantHandle(address)
+    await pb.failWantHandle(address, StorageFailedEngineError, "test error")
+    check handle.finished
+
+  test "resolve completes handle":
+    let pb = PendingBlocksManager.new()
+    let handle = pb.getWantHandle(address)
+    let peerCtx = makePeerCtx(makePeerId())
+    discard pb.markRequested(address, peerCtx, 60.seconds)
+    await pb.resolve(address, blk)
+    let delivery = await handle
+    check delivery.blk == blk
+    check delivery.address == address

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -1,6 +1,7 @@
 import std/sequtils
 import std/algorithm
 import std/heapqueue
+import std/importutils
 
 import pkg/chronos
 import pkg/libp2p
@@ -9,11 +10,15 @@ import pkg/questionable
 
 import pkg/archivist/rng
 import pkg/archivist/blocktype as bt
-import pkg/archivist/blockexchange
+import pkg/archivist/blockexchange {.all.}
+import pkg/archivist/blockexchange/engine/pendingblocks {.all.}
 import pkg/archivist/utils/trackedfutures
 
 import ../helpers
 import ../../asynctest
+
+privateAccess(PendingBlocksManager)
+privateAccess(BatchReq)
 
 proc makePeerId(): PeerId =
   let seckey = PrivateKey.random(Rng.instance()[]).tryGet()
@@ -43,7 +48,8 @@ suite "Pending Blocks":
       @[blk].mapIt(BlockDelivery(blk: it, address: it.address))
     )
     await sleepAsync(0.millis)
-      # trigger the event loop, otherwise the block finishes before poll runs
+
+    # trigger the event loop, otherwise the block finishes before poll runs
     let resolved = await handle
     check resolved.blk == blk
     check resolved.address == blk.address
@@ -108,7 +114,7 @@ suite "Pending Blocks":
       pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peerCtx, 1.millis) != nil
+    pendingBlocks.markRequested(address, peerCtx, 1.millis)
     check eventually timedOut
 
   test "Should cancel request timeout on clear":
@@ -127,9 +133,10 @@ suite "Pending Blocks":
       pendingBlocks = PendingBlocksManager.new()
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
+    pendingBlocks.markRequested(address, peerCtx, 10.millis)
     await pendingBlocks.clearRequest(address, peerCtx)
     await sleepAsync(50.millis)
+
     check not timedOut
 
   test "Should cancel request timeout on resolve":
@@ -148,7 +155,8 @@ suite "Pending Blocks":
       pendingBlocks = PendingBlocksManager.new()
 
     let handle = pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
+    pendingBlocks.markRequested(address, peerCtx, 10.millis)
+
     await pendingBlocks.resolve(@[BlockDelivery(blk: blk, address: blk.address)])
     check (await handle).blk == blk
     await sleepAsync(20.millis)
@@ -170,8 +178,9 @@ suite "Pending Blocks":
       pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     let handle = pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, peerCtx, 10.millis) != nil
+    pendingBlocks.markRequested(address, peerCtx, 10.millis)
     await handle.cancelAndWait()
+
     check eventually blk.cid notin pendingBlocks
     await sleepAsync(20.millis)
     check not timedOut
@@ -196,9 +205,10 @@ suite "Pending Blocks":
       pendingBlocks = PendingBlocksManager.new(onTimeout = onTimeout)
 
     discard pendingBlocks.getWantHandle(blk.cid)
-    check pendingBlocks.markRequested(address, firstPeerCtx, 20.millis) != nil
+    pendingBlocks.markRequested(address, firstPeerCtx, 20.millis)
     await pendingBlocks.clearRequest(address, firstPeerCtx)
-    check pendingBlocks.markRequested(address, secondPeerCtx, 1.millis) != nil
+    pendingBlocks.markRequested(address, secondPeerCtx, 1.millis)
+
     check eventually timeouts.len == 1
     check timeouts[0] == secondPeerId
     await sleepAsync(25.millis)
@@ -243,16 +253,18 @@ suite "PendingBlocks ownership model":
     check address in pb
     check not pb.isRequested(address)
 
-  test "markRequested sets in-flight and decrements retries":
+  test "markRequested properly sets all fields":
     let pb = PendingBlocksManager.new()
     discard pb.getWantHandle(address)
     let retriesBefore = pb.retries(address)
     let peerCtx = makePeerCtx(makePeerId())
 
-    discard pb.markRequested(address, peerCtx, 60.seconds)
+    pb.markRequested(address, peerCtx, 60.seconds)
 
     check pb.isRequested(address)
     check pb.retries(address) == retriesBefore - 1
+    check pb.getRequestPeer(address) == peerCtx.id.some
+    check address in peerCtx.blocksRequested
 
   test "clearRequest clears in-flight and removes from blocksRequested":
     let
@@ -261,12 +273,16 @@ suite "PendingBlocks ownership model":
       pb = PendingBlocksManager.new()
 
     discard pb.getWantHandle(address)
-    discard pb.markRequested(address, peerCtx, 60.seconds)
+    pb.markRequested(address, peerCtx, 60.seconds)
+
     check pb.isRequested(address)
     check address in peerCtx.blocksRequested
 
     await pb.clearRequest(address, peerCtx)
+
     check not pb.isRequested(address)
+    check pb.getRequestPeer(address) == PeerId.none
+
     check address notin peerCtx.blocksRequested
 
   test "failWantHandle fails request and removes from blocksRequested":
@@ -276,11 +292,12 @@ suite "PendingBlocks ownership model":
       pb = PendingBlocksManager.new()
       handle = pb.getWantHandle(address)
 
-    discard pb.markRequested(address, peerCtx, 60.seconds)
+    pb.markRequested(address, peerCtx, 60.seconds)
     check address in peerCtx.blocksRequested
 
     await pb.failWantHandle(address, StorageFailedEngineError, "test error")
     check handle.finished
+    check address notin pb
     check address notin peerCtx.blocksRequested
 
   test "resolve completes handle and removes from blocksRequested":
@@ -290,14 +307,17 @@ suite "PendingBlocks ownership model":
       pb = PendingBlocksManager.new()
       handle = pb.getWantHandle(address)
 
-    discard pb.markRequested(address, peerCtx, 60.seconds)
+    pb.markRequested(address, peerCtx, 60.seconds)
     check address in peerCtx.blocksRequested
 
     await pb.resolve(address, blk)
-    check address notin peerCtx.blocksRequested
     let delivery = await handle
+
     check delivery.blk == blk
     check delivery.address == address
+
+    check address notin peerCtx.blocksRequested
+    check address notin pb
 
   test "timeout requeues block and clears peer assignment":
     var timedOut = false
@@ -313,7 +333,8 @@ suite "PendingBlocks ownership model":
       pb = PendingBlocksManager.new(onTimeout = onTimeout)
 
     discard pb.getWantHandle(address)
-    discard pb.markRequested(address, peerCtx, 10.millis)
+    pb.markRequested(address, peerCtx, 10.millis)
+
     check pb.isRequested(address)
     check address in peerCtx.blocksRequested
 
@@ -321,7 +342,7 @@ suite "PendingBlocks ownership model":
 
     check not pb.isRequested(address)
     check address in pb
-    check peerCtx.blocksRequested.len == 0
+    check address notin peerCtx.blocksRequested
 
   test "retryAddresses removes from blocksRequested and requeues":
     let
@@ -330,7 +351,8 @@ suite "PendingBlocks ownership model":
       pb = PendingBlocksManager.new()
 
     discard pb.getWantHandle(address)
-    discard pb.markRequested(address, peerCtx, 60.seconds)
+    pb.markRequested(address, peerCtx, 60.seconds)
+
     check address in peerCtx.blocksRequested
 
     await pb.retryAddresses(@[address], 0.millis)
@@ -338,49 +360,19 @@ suite "PendingBlocks ownership model":
     check not pb.isRequested(address)
     check address in pb
 
-  test "markRequested with same peer is idempotent":
-    let
-      peerId = makePeerId()
-      peerCtx = makePeerCtx(peerId)
-      pb = PendingBlocksManager.new()
-
-    discard pb.getWantHandle(address)
-    let retriesBefore = pb.retries(address)
-
-    let result1 = pb.markRequested(address, peerCtx, 60.seconds)
-    check result1 == peerCtx
-    check pb.retries(address) == retriesBefore - 1
-
-    let result2 = pb.markRequested(address, peerCtx, 60.seconds)
-    check result2 == peerCtx
-    check pb.retries(address) == retriesBefore - 1
-
-  test "markRequested with different peer returns previous":
-    let
-      peerId1 = makePeerId()
-      peerCtx1 = makePeerCtx(peerId1)
-      peerId2 = makePeerId()
-      peerCtx2 = makePeerCtx(peerId2)
-      pb = PendingBlocksManager.new()
-
-    discard pb.getWantHandle(address)
-    let result1 = pb.markRequested(address, peerCtx1, 60.seconds)
-    check result1 == peerCtx1
-
-    let result2 = pb.markRequested(address, peerCtx2, 60.seconds)
-    check result2 == peerCtx1
-    check pb.getRequestPeerCtx(address) == peerCtx1
-
-  test "scheduler respects priority ordering":
+  test "Scheduler respects priority ordering":
+    # Priority is a tiebreaker when readyAt is equal. We request both items
+    # through the scheduler and verify both are dispatched.
     let
       pb = PendingBlocksManager.new(batchSize = 1, batchDeadline = 1.millis)
       lowPriorityAddress = BlockAddress.init(bt.Block.new("low".toBytes).tryGet.cid)
       highPriorityAddress = BlockAddress.init(bt.Block.new("high".toBytes).tryGet.cid)
       bothSent = newFuture[void]()
+      peerId = makePeerId()
 
     var sentAddresses: seq[BlockAddress]
 
-    proc sendBatch(
+    pb.sendBatch = proc(
         peer: BlockExcPeerCtx, batch: seq[BlockAddress]
     ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
       sentAddresses.add(batch[0])
@@ -388,16 +380,14 @@ suite "PendingBlocks ownership model":
         bothSent.complete()
       success()
 
-    let peerCtx = makePeerCtx(makePeerId())
-    pb.sendBatch = sendBatch
     pb.getPeerForBlock = proc(
         address: BlockAddress
     ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
-      success peerCtx
+      success makePeerCtx(peerId)
 
-    discard pb.start()
+    await pb.start()
 
-    # Add low priority first, then high priority (higher numeric = higher priority in max-heap)
+    # The heap correctly orders by readyAt first, then priority.
     discard pb.getWantHandle(lowPriorityAddress, priority = 1)
     discard pb.getWantHandle(highPriorityAddress, priority = 10)
 
@@ -405,5 +395,192 @@ suite "PendingBlocks ownership model":
     await pb.stop()
 
     check sentAddresses.len == 2
-    check sentAddresses[0] == lowPriorityAddress # priority 1 pops first (min-heap)
-    check sentAddresses[1] == highPriorityAddress
+    check lowPriorityAddress in sentAddresses
+    check highPriorityAddress in sentAddresses
+
+  test "Disconnect monitor requeues blocks and cleans byPeer":
+    let
+      pb = PendingBlocksManager.new()
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      blk = Block.new("data".toBytes).tryGet
+      sendBatchEvent = newAsyncEvent()
+
+    var getPeerCallCount = 0
+
+    # Block sendBatch so the address stays in-flight (blocksRequested set)
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      # Block so the batch worker stays stuck
+      sendBatchEvent.fire()
+      success()
+
+    # Return peer on first call only, then fail to prevent re-dispatch loop
+    pb.getPeerForBlock = proc(
+        address: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      getPeerCallCount.inc()
+      if getPeerCallCount == 1:
+        success peerCtx
+      else:
+        # Use generic error so pushPeerBlock returns without retrying
+        failure(newException(NoPeerForBlockError, "no more peers"))
+
+    await pb.start()
+
+    # Request a block so it goes through pushPeerBlock -> byPeer entry
+    let handle = pb.getWantHandle(address)
+
+    await sendBatchEvent.wait()
+
+    # Verify block is in-flight
+    check address in pb
+    check address in peerCtx.blocksRequested
+
+    # Simulate peer disconnect while block is in-flight
+    peerCtx.disconnect()
+    # discard await handle
+
+    await pb.byPeer[peerCtx.id].monitorFut
+
+    # Check BEFORE stop (stop clears self.blocks)
+    check address in pb
+    check not pb.isRequested(address)
+    check peerCtx.id notin pb.byPeer
+
+    await pb.stop()
+
+  test "Send failure requeues batch":
+    var sendCount = 0
+    let
+      pb = PendingBlocksManager.new(discoveryTimeout = 500.millis)
+      peerCtx = makePeerCtx(makePeerId())
+      batchSendEvent = newAsyncEvent()
+
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      sendCount.inc()
+      if sendCount == 1:
+        # First send fails
+        failure(newException(CatchableError, "send failed"))
+      else:
+        batchSendEvent.fire()
+        success()
+
+    pb.getPeerForBlock = proc(
+        address: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    await pb.start()
+    discard pb.getWantHandle(address)
+
+    await batchSendEvent.wait()
+
+    # Check BEFORE stop (stop clears self.blocks)
+    check sendCount >= 2 # retried at least once
+    check address in pb
+
+    await pb.stop()
+
+  test "Generation staleness skips stale heap entries":
+    let
+      pb = PendingBlocksManager.new()
+      peerCtx = makePeerCtx(makePeerId())
+
+    var called = 0
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      called.inc()
+      check called == 1
+      check batch.len == 1
+      check batch[0]
+
+      success()
+
+    pb.getPeerForBlock = proc(
+        address: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    await pb.start()
+
+    # Request the same address twice to create multiple heap entries
+    let
+      handle1 = pb.getWantHandle(address)
+      handle2 = pb.getWantHandle(address)
+
+    await sleepAsync(500.millis)
+    await pb.stop()
+
+    # Should only be sent once (stale entry skipped)
+    check sentAddresses.len == 1
+    check sentAddresses[0] == address
+
+  test "validateBlock rejects missing block":
+    # validateBlock is internal, tested indirectly through pushPeerBlock
+    # If a block is removed from self.blocks after being pushed to the pipe,
+    # the batch worker should skip it
+    let
+      pb = PendingBlocksManager.new()
+      peerCtx = makePeerCtx(makePeerId())
+      otherAddr = BlockAddress.init(bt.Block.new("other".toBytes).tryGet.cid)
+
+    var sentAddresses: seq[BlockAddress]
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      sentAddresses.add(batch[0])
+      success()
+
+    pb.getPeerForBlock = proc(
+        a: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    await pb.start()
+
+    # Request a block
+    let h = pb.getWantHandle(address)
+
+    # Wait for it to be sent
+    await sleepAsync(500.millis)
+    await pb.stop()
+
+    # The block should have been sent
+    check sentAddresses.len == 1
+    check sentAddresses[0] == address
+
+  test "stop drains queued pipe items":
+    let
+      pb = PendingBlocksManager.new()
+      peerCtx = makePeerCtx(makePeerId())
+
+    # Block sendBatch so the batch worker stays stuck
+    pb.sendBatch = proc(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      await sleepAsync(10.hours)
+      success()
+
+    pb.getPeerForBlock = proc(
+        address: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    await pb.start()
+
+    # Request a block - it will go to the pipe, batch worker will get stuck in sendBatch
+    discard pb.getWantHandle(address)
+
+    # Wait for the block to reach the batch worker
+    await sleepAsync(200.millis)
+
+    # Stop should cancel the batch worker (tracked futures) and return cleanly
+    await pb.stop()
+
+    # If stop completes without hanging, the drain worked correctly
+    check true

--- a/tests/archivist/blockexchange/testpendingblocks.nim
+++ b/tests/archivist/blockexchange/testpendingblocks.nim
@@ -243,7 +243,7 @@ suite "PendingBlocks ownership model":
     check address in pb
     check not pb.isRequested(address)
 
-  test "markRequested sets in-flight":
+  test "markRequested sets in-flight and decrements retries":
     let pb = PendingBlocksManager.new()
     discard pb.getWantHandle(address)
     let retriesBefore = pb.retries(address)
@@ -252,31 +252,158 @@ suite "PendingBlocks ownership model":
     discard pb.markRequested(address, peerCtx, 60.seconds)
 
     check pb.isRequested(address)
-    # markRequested decrements retries internally now
     check pb.retries(address) == retriesBefore - 1
 
-  test "clearRequest clears in-flight":
-    let pb = PendingBlocksManager.new()
+  test "clearRequest clears in-flight and removes from blocksRequested":
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      pb = PendingBlocksManager.new()
+
     discard pb.getWantHandle(address)
-    let peerCtx = makePeerCtx(makePeerId())
     discard pb.markRequested(address, peerCtx, 60.seconds)
     check pb.isRequested(address)
+    check address in peerCtx.blocksRequested
 
     await pb.clearRequest(address, peerCtx)
     check not pb.isRequested(address)
+    check address notin peerCtx.blocksRequested
 
-  test "failWantHandle fails request":
-    let pb = PendingBlocksManager.new()
-    let handle = pb.getWantHandle(address)
+  test "failWantHandle fails request and removes from blocksRequested":
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      pb = PendingBlocksManager.new()
+      handle = pb.getWantHandle(address)
+
+    discard pb.markRequested(address, peerCtx, 60.seconds)
+    check address in peerCtx.blocksRequested
+
     await pb.failWantHandle(address, StorageFailedEngineError, "test error")
     check handle.finished
+    check address notin peerCtx.blocksRequested
 
-  test "resolve completes handle":
-    let pb = PendingBlocksManager.new()
-    let handle = pb.getWantHandle(address)
-    let peerCtx = makePeerCtx(makePeerId())
+  test "resolve completes handle and removes from blocksRequested":
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      pb = PendingBlocksManager.new()
+      handle = pb.getWantHandle(address)
+
     discard pb.markRequested(address, peerCtx, 60.seconds)
+    check address in peerCtx.blocksRequested
+
     await pb.resolve(address, blk)
+    check address notin peerCtx.blocksRequested
     let delivery = await handle
     check delivery.blk == blk
     check delivery.address == address
+
+  test "timeout requeues block and clears peer assignment":
+    var timedOut = false
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      onTimeout = proc(
+          timeoutAddress: BlockAddress, timeoutPeer: PeerId
+      ) {.gcsafe, async: (raises: [CancelledError]).} =
+        check timeoutAddress == address
+        check timeoutPeer == peerId
+        timedOut = true
+      pb = PendingBlocksManager.new(onTimeout = onTimeout)
+
+    discard pb.getWantHandle(address)
+    discard pb.markRequested(address, peerCtx, 10.millis)
+    check pb.isRequested(address)
+    check address in peerCtx.blocksRequested
+
+    check eventually timedOut
+
+    check not pb.isRequested(address)
+    check address in pb
+    check peerCtx.blocksRequested.len == 0
+
+  test "retryAddresses removes from blocksRequested and requeues":
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      pb = PendingBlocksManager.new()
+
+    discard pb.getWantHandle(address)
+    discard pb.markRequested(address, peerCtx, 60.seconds)
+    check address in peerCtx.blocksRequested
+
+    await pb.retryAddresses(@[address], 0.millis)
+    check address notin peerCtx.blocksRequested
+    check not pb.isRequested(address)
+    check address in pb
+
+  test "markRequested with same peer is idempotent":
+    let
+      peerId = makePeerId()
+      peerCtx = makePeerCtx(peerId)
+      pb = PendingBlocksManager.new()
+
+    discard pb.getWantHandle(address)
+    let retriesBefore = pb.retries(address)
+
+    let result1 = pb.markRequested(address, peerCtx, 60.seconds)
+    check result1 == peerCtx
+    check pb.retries(address) == retriesBefore - 1
+
+    let result2 = pb.markRequested(address, peerCtx, 60.seconds)
+    check result2 == peerCtx
+    check pb.retries(address) == retriesBefore - 1
+
+  test "markRequested with different peer returns previous":
+    let
+      peerId1 = makePeerId()
+      peerCtx1 = makePeerCtx(peerId1)
+      peerId2 = makePeerId()
+      peerCtx2 = makePeerCtx(peerId2)
+      pb = PendingBlocksManager.new()
+
+    discard pb.getWantHandle(address)
+    let result1 = pb.markRequested(address, peerCtx1, 60.seconds)
+    check result1 == peerCtx1
+
+    let result2 = pb.markRequested(address, peerCtx2, 60.seconds)
+    check result2 == peerCtx1
+    check pb.getRequestPeerCtx(address) == peerCtx1
+
+  test "scheduler respects priority ordering":
+    let
+      pb = PendingBlocksManager.new(batchSize = 1, batchDeadline = 1.millis)
+      lowPriorityAddress = BlockAddress.init(bt.Block.new("low".toBytes).tryGet.cid)
+      highPriorityAddress = BlockAddress.init(bt.Block.new("high".toBytes).tryGet.cid)
+      bothSent = newFuture[void]()
+
+    var sentAddresses: seq[BlockAddress]
+
+    proc sendBatch(
+        peer: BlockExcPeerCtx, batch: seq[BlockAddress]
+    ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+      sentAddresses.add(batch[0])
+      if sentAddresses.len == 2 and not bothSent.finished:
+        bothSent.complete()
+      success()
+
+    let peerCtx = makePeerCtx(makePeerId())
+    pb.sendBatch = sendBatch
+    pb.getPeerForBlock = proc(
+        address: BlockAddress
+    ): Future[?!BlockExcPeerCtx] {.gcsafe, async: (raises: [CancelledError]).} =
+      success peerCtx
+
+    discard pb.start()
+
+    # Add low priority first, then high priority (higher numeric = higher priority in max-heap)
+    discard pb.getWantHandle(lowPriorityAddress, priority = 1)
+    discard pb.getWantHandle(highPriorityAddress, priority = 10)
+
+    await bothSent.wait(1.seconds)
+    await pb.stop()
+
+    check sentAddresses.len == 2
+    check sentAddresses[0] == lowPriorityAddress # priority 1 pops first (min-heap)
+    check sentAddresses[1] == highPriorityAddress

--- a/tests/archivist/examples.nim
+++ b/tests/archivist/examples.nim
@@ -26,7 +26,7 @@ proc example*(_: type PeerId): PeerId =
   PeerId.init(key.getPublicKey().get).get
 
 proc example*(_: type BlockExcPeerCtx): BlockExcPeerCtx =
-  BlockExcPeerCtx(id: PeerId.example)
+  BlockExcPeerCtx.new(PeerId.example)
 
 proc example*(_: type Cid): Cid =
   bt.Block.example.cid

--- a/tests/archivist/marketplace/sales/states/testfilled.nim
+++ b/tests/archivist/marketplace/sales/states/testfilled.nim
@@ -1,5 +1,3 @@
-import pkg/questionable/results
-
 import pkg/archivist/marketplace/contracts/requests
 import pkg/archivist/marketplace/sales
 import pkg/archivist/marketplace/sales/salesagent
@@ -64,8 +62,12 @@ suite "sales state 'filled'":
     check index == mockSlot.slotIndex
     check expiry == expectedExpiry
 
-  test "switches to error state when slot is filled by another host":
+  test "switches to error state when slot is filled by another host and cleans up slot data":
     mockSlot.host = Address.example
     marketplace.filled = @[mockSlot]
     let next = await state.run(agent)
     check !next of SaleErrored
+    check storage.slotFailedCalls.len > 0
+    let (delCid, delIdx) = storage.slotFailedCalls[0]
+    check delCid == request.content.cid
+    check delIdx == slotIndex

--- a/tests/archivist/marketplace/sales/states/testfilling.nim
+++ b/tests/archivist/marketplace/sales/states/testfilling.nim
@@ -12,6 +12,7 @@ import ../../../examples
 import ../../../helpers
 import ../../../helpers/mockmarketplace
 import ../../../helpers/mockclock
+import ../mockstorage
 
 suite "sales state 'filling'":
   let request = StorageRequest.example
@@ -20,12 +21,14 @@ suite "sales state 'filling'":
   var state: SaleFilling
   var marketplace: MockMarketplace
   var clock: MockClock
+  var storage: MockStorage
   var agent: SalesAgent
 
   setup:
     clock = MockClock.new()
     marketplace = MockMarketplace.new()
-    let context = SalesContext(marketplace: marketplace, clock: clock)
+    storage = MockStorage.new()
+    let context = SalesContext(marketplace: marketplace, clock: clock, storage: storage)
     var slotInfo = SlotInfo.init(slot.id)
     slotInfo.slot = slot
     agent = newSalesAgent(context, slotInfo)
@@ -39,7 +42,7 @@ suite "sales state 'filling'":
     let next = state.onFailed(request)
     check !next of SaleFailed
 
-  test "run switches to ignored when slot is not free":
+  test "run switches to ignored when slot is not free and cleans up slot data":
     let error = newException(
       SlotStateMismatchError, "Failed to fill slot because the slot is not free"
     )
@@ -50,8 +53,12 @@ suite "sales state 'filling'":
     let next = !(await state.run(agent))
     check next of SaleIgnored
     check SaleIgnored(next).reprocessSlot == false
+    check storage.slotFailedCalls.len > 0
+    let (delCid, delIdx) = storage.slotFailedCalls[0]
+    check delCid == request.content.cid
+    check delIdx == slotIndex
 
-  test "run switches to errored with other error ":
+  test "run switches to errored with other error and does not clean up slot data":
     let error = newException(MarketplaceError, "some error")
     marketplace.setErrorOnFillSlot(error)
     marketplace.requested.add(request)
@@ -62,3 +69,4 @@ suite "sales state 'filling'":
 
     let errored = SaleErrored(next)
     check errored.error == error
+    check storage.slotFailedCalls.len == 0

--- a/tests/archivist/node/tempnode.nim
+++ b/tests/archivist/node/tempnode.nim
@@ -13,6 +13,7 @@ import pkg/archivist/systemclock
 type TemporaryNode* = ref object
   repoDs: KVStore
   metaDs: KVStore
+  discoveryDs: KVStore
   tp: Taskpool
   localStore: RepoStore
   p2p: Switch
@@ -38,9 +39,9 @@ proc initializeNetwork(temporary: TemporaryNode) =
   temporary.exchangeNetwork = BlockExcnetwork.new(temporary.p2p)
   let privateKey = temporary.p2p.peerInfo.privateKey
   let address = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet()
-  let discoveryDs = SQLiteKVStore.new(SqliteMemory, temporary.tp).tryGet()
+  temporary.discoveryDs = SQLiteKVStore.new(SqliteMemory, temporary.tp).tryGet()
   temporary.discoveryNetwork =
-    Discovery.new(privateKey, announceAddrs = @[address], store = discoveryDs)
+    Discovery.new(privateKey, announceAddrs = @[address], store = temporary.discoveryDs)
 
 proc initializePendingBlocks(temporary: TemporaryNode) =
   temporary.pendingBlocks = PendingBlocksManager.new()
@@ -90,6 +91,7 @@ proc destroy*(temporary: TemporaryNode) {.async.} =
   await temporary.node.stop()
   (await temporary.repoDs.close()).tryGet()
   (await temporary.metaDs.close()).tryGet()
+  (await temporary.discoveryDs.close()).tryGet()
   temporary.tp.shutdown()
 
 func node*(temporary: TemporaryNode): ArchivistNodeRef =

--- a/tests/archivist/testasyncheapqueue.nim
+++ b/tests/archivist/testasyncheapqueue.nim
@@ -219,3 +219,52 @@ asyncchecksuite "Asynchronous Tests":
     let del = heap[3]
     heap.delete(del)
     check heap.find(del) < 0
+
+  test "Test replace":
+    var heap = newAsyncHeapQueue[int]()
+    let data = [3, 7, 5, 1, 9]
+    for item in data:
+      check heap.pushNoWait(item).isOk
+
+    let smallest = heap[0]
+    let replaced = heap.replace(8).tryGet()
+    check replaced == smallest
+    # After removing 1 and inserting 8, the smallest should be 3
+    check heap[0] == 3
+
+  test "Test replace on empty returns err":
+    var heap = newAsyncHeapQueue[int]()
+    check heap.replace(1).isErr
+    check heap.replace(1).error == AsyncHQErrors.Empty
+
+  test "Test pushPopNoWait returns smallest":
+    var heap = newAsyncHeapQueue[int]()
+    let data = [3, 7, 5, 1, 9]
+    for item in data:
+      check heap.pushNoWait(item).isOk
+
+    # push 0 which is smaller than any item, should be returned directly
+    let result = heap.pushPopNoWait(0).tryGet()
+    check result == 0
+    # heap should be unchanged (0 never entered it)
+    check heap.len == 5
+    check heap[0] == 1
+
+  test "Test pushPopNoWait pushes larger item":
+    var heap = newAsyncHeapQueue[int]()
+    let data = [3, 7, 5, 1, 9]
+    for item in data:
+      check heap.pushNoWait(item).isOk
+
+    let smallest = heap[0]
+    # push 4 which is larger than smallest, should pop smallest and keep 4
+    let result = heap.pushPopNoWait(4).tryGet()
+    check result == smallest
+    # heap should contain 4 instead of smallest
+    check heap.len == 5
+    check 4 in heap
+
+  test "Test pushPopNoWait on empty returns err":
+    var heap = newAsyncHeapQueue[int]()
+    check heap.pushPopNoWait(1).isErr
+    check heap.pushPopNoWait(1).error == AsyncHQErrors.Empty


### PR DESCRIPTION
This revamps the scheduling pipeline for send batches.

- PendingBlockManager (to be renamed to BlockScheduler) now owns the scheduling pipeline
- Batches are constructed per peer, not split at the point of sending to different peers (current incomplete implementation in main)

The main benefit is the flow & ownership consolidation of `send batches`, as well as the refined and tightened flow.