### PR TITLE
Feat/advertiser readiness

### DIFF
--- a/archivist/archivist.nim
+++ b/archivist/archivist.nim
@@ -18,6 +18,8 @@ import pkg/libp2p
 import pkg/confutils
 import pkg/confutils/defs
 import pkg/stew/io2
+import pkg/questionable
+import pkg/questionable/results
 import pkg/kvstore
 import pkg/ethers except Rng
 
@@ -49,6 +51,7 @@ type
     repoStore: RepoStore
     maintenance: BlockMaintainer
     natTraversal: NatTraversal
+    discoveryStore: KVStore
     taskpool: Taskpool
 
   NodePrivateKey* = libp2p.PrivateKey # alias
@@ -112,20 +115,16 @@ proc start*(s: NodeServer) {.async.} =
 proc stop*(s: NodeServer) {.async.} =
   notice "Stopping node"
 
-  let res = await noCancel allFinishedFailed[void](
-    @[
-      s.restServer.stop(),
-      s.archivistNode.switch.stop(),
-      s.archivistNode.stop(),
-      s.repoStore.stop(),
-      s.maintenance.stop(),
-      s.natTraversal.stop(),
-    ]
-  )
+  await s.restServer.stop()
+  await s.archivistNode.stop()
+  await s.maintenance.stop()
+  await s.natTraversal.stop()
+  await s.repoStore.stop()
+  await s.archivistNode.switch.stop()
 
-  if res.failure.len > 0:
-    error "Failed to stop node", failures = res.failure.len
-    raiseAssert "Failed to stop node"
+  if not s.discoveryStore.isNil:
+    if err =? (await s.discoveryStore.close()).errorOption:
+      error "Failed to close discovery store", err = err.msg
 
   if not s.taskpool.isNil:
     s.taskpool.shutdown()
@@ -267,5 +266,6 @@ proc new*(
     repoStore: repoStore,
     maintenance: maintenance,
     natTraversal: natTraversal,
+    discoveryStore: discoveryStore,
     taskpool: tp,
   )

--- a/archivist/blockexchange/engine/advertiser.nim
+++ b/archivist/blockexchange/engine/advertiser.nim
@@ -35,6 +35,9 @@ declareGauge(archivist_inflight_advertise, "inflight advertise requests")
 const
   DefaultConcurrentAdvertRequests = 10
   DefaultAdvertiseLoopSleep = 30.minutes
+  DefaultMinAdvertisePeers = 16
+  DefaultAdvertiseRetrySleep = 30.seconds
+  DefaultAdvertiseRetryWindow = 10.minutes
 
 type Advertiser* = ref object of RootObj
   localStore*: BlockStore # Local block store for this instance
@@ -49,6 +52,11 @@ type Advertiser* = ref object of RootObj
 
   advertiseLocalStoreLoopSleep: Duration # Advertise loop sleep
   inFlightAdvReqs*: Table[Cid, Future[void]] # Inflight advertise requests
+  pendingAdvRetries: Table[Cid, Future[void]] # Delayed sparse retry tasks
+  minAdvertisePeers: int # Desired routing-table size before advertising
+  advertiseRetrySleep: Duration # Delay before retrying sparse startup advertise
+  advertiseRetryWindow: Duration # Startup window for sparse advertise retries
+  startedAt: Moment # Time advertiser started
 
 proc addCidToQueue(b: Advertiser, cid: Cid) {.async: (raises: [CancelledError]).} =
   if cid notin b.advertiseQueue:
@@ -105,6 +113,36 @@ proc advertiseLocalStoreLoop(b: Advertiser) {.async: (raises: []).} =
 
   info "Exiting advertise task loop"
 
+proc hasElapsed(since: Moment, dur: Duration): bool =
+  (Moment.now() - since) >= dur
+
+proc shouldRetryAdvertise(b: Advertiser): bool =
+  b.minAdvertisePeers > 0 and b.discovery.nodesDiscovered() < b.minAdvertisePeers and
+    not hasElapsed(b.startedAt, b.advertiseRetryWindow)
+
+proc delayedAdvertiseRetry(b: Advertiser, cid: Cid) {.async: (raises: []).} =
+  try:
+    await sleepAsync(b.advertiseRetrySleep)
+
+    if b.advertiserRunning and b.shouldRetryAdvertise():
+      trace "Requeueing sparse startup advertisement",
+        cid, nodes = b.discovery.nodesDiscovered(), target = b.minAdvertisePeers
+      await b.addCidToQueue(cid)
+  except CancelledError:
+    trace "Cancelled sparse startup advertisement retry", cid
+  except CatchableError as exc:
+    warn "Sparse startup advertisement retry failed", cid, err = exc.msg
+  finally:
+    b.pendingAdvRetries.del(cid)
+
+proc scheduleAdvertiseRetry(b: Advertiser, cid: Cid) =
+  if cid in b.pendingAdvRetries:
+    return
+
+  let retry = b.delayedAdvertiseRetry(cid)
+  b.pendingAdvRetries[cid] = retry
+  b.trackedFutures.track(retry)
+
 proc processQueueLoop(b: Advertiser) {.async: (raises: []).} =
   try:
     while b.advertiserRunning:
@@ -117,11 +155,14 @@ proc processQueueLoop(b: Advertiser) {.async: (raises: []).} =
       b.inFlightAdvReqs[cid] = request
       archivist_inflight_advertise.set(b.inFlightAdvReqs.len.int64)
 
-      defer:
+      try:
+        await request
+      finally:
         b.inFlightAdvReqs.del(cid)
         archivist_inflight_advertise.set(b.inFlightAdvReqs.len.int64)
 
-      await request
+      if b.shouldRetryAdvertise():
+        b.scheduleAdvertiseRetry(cid)
   except CancelledError:
     warn "Cancelled advertise task runner"
 
@@ -147,6 +188,7 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
   b.localStore.onBlockStored = onBlock.some
 
   b.advertiserRunning = true
+  b.startedAt = Moment.now()
   for i in 0 ..< b.concurrentAdvReqs:
     let fut = b.processQueueLoop()
     b.trackedFutures.track(fut)
@@ -176,6 +218,9 @@ proc new*(
     discovery: Discovery,
     concurrentAdvReqs = DefaultConcurrentAdvertRequests,
     advertiseLocalStoreLoopSleep = DefaultAdvertiseLoopSleep,
+    minAdvertisePeers = DefaultMinAdvertisePeers,
+    advertiseRetrySleep = DefaultAdvertiseRetrySleep,
+    advertiseRetryWindow = DefaultAdvertiseRetryWindow,
 ): Advertiser =
   ## Create a advertiser instance
   ##
@@ -186,5 +231,9 @@ proc new*(
     advertiseQueue: newAsyncQueue[Cid](concurrentAdvReqs),
     trackedFutures: TrackedFutures.new(),
     inFlightAdvReqs: initTable[Cid, Future[void]](),
+    pendingAdvRetries: initTable[Cid, Future[void]](),
     advertiseLocalStoreLoopSleep: advertiseLocalStoreLoopSleep,
+    minAdvertisePeers: minAdvertisePeers,
+    advertiseRetrySleep: advertiseRetrySleep,
+    advertiseRetryWindow: advertiseRetryWindow,
   )

--- a/archivist/blockexchange/engine/advertiser.nim
+++ b/archivist/blockexchange/engine/advertiser.nim
@@ -124,8 +124,8 @@ proc delayedAdvertiseRetry(b: Advertiser, cid: Cid) {.async: (raises: []).} =
   try:
     await sleepAsync(b.advertiseRetrySleep)
 
-    if b.advertiserRunning and b.shouldRetryAdvertise():
-      trace "Requeueing sparse startup advertisement",
+    if b.advertiserRunning:
+      trace "Requeueing advertisement retry",
         cid, nodes = b.discovery.nodesDiscovered(), target = b.minAdvertisePeers
       await b.addCidToQueue(cid)
   except CancelledError:

--- a/archivist/blockexchange/engine/advertiser.nim
+++ b/archivist/blockexchange/engine/advertiser.nim
@@ -9,6 +9,7 @@
 
 {.push raises: [].}
 
+import std/sequtils
 import pkg/chronos
 import pkg/libp2p/cid
 import pkg/libp2p/multicodec
@@ -124,7 +125,7 @@ proc delayedAdvertiseRetry(b: Advertiser, cid: Cid) {.async: (raises: []).} =
   try:
     await sleepAsync(b.advertiseRetrySleep)
 
-    if b.advertiserRunning:
+    if b.advertiserRunning and not hasElapsed(b.startedAt, b.advertiseRetryWindow):
       trace "Requeueing advertisement retry",
         cid, nodes = b.discovery.nodesDiscovered(), target = b.minAdvertisePeers
       await b.addCidToQueue(cid)
@@ -166,6 +167,8 @@ proc processQueueLoop(b: Advertiser) {.async: (raises: []).} =
   except CancelledError:
     warn "Cancelled advertise task runner"
 
+  await noCancel allFutures(toSeq(b.inFlightAdvReqs.values).mapIt(it.cancelAndWait()))
+
   info "Exiting advertise task runner"
 
 proc start*(b: Advertiser) {.async: (raises: []).} =
@@ -176,7 +179,10 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
 
   # The advertiser is expected to be started only once.
   if b.advertiserRunning:
-    raiseAssert "Advertiser can only be started once - this should not happen"
+    warn "Advertiser can only be started once - this should not happen"
+    return
+
+  b.advertiserRunning = true
 
   proc onBlock(cid: Cid) {.async: (raises: []).} =
     try:
@@ -187,7 +193,6 @@ proc start*(b: Advertiser) {.async: (raises: []).} =
   doAssert(b.localStore.onBlockStored.isNone())
   b.localStore.onBlockStored = onBlock.some
 
-  b.advertiserRunning = true
   b.startedAt = Moment.now()
   for i in 0 ..< b.concurrentAdvReqs:
     let fut = b.processQueueLoop()
@@ -205,11 +210,12 @@ proc stop*(b: Advertiser) {.async: (raises: []).} =
     warn "Stopping advertiser without starting it"
     return
 
+  trace "Stopping advertise loop and tasks"
+  await b.trackedFutures.cancelTracked()
+
   b.advertiserRunning = false
   # Stop incoming tasks from callback and localStore loop
   b.localStore.onBlockStored = CidCallback.none
-  trace "Stopping advertise loop and tasks"
-  await b.trackedFutures.cancelTracked()
   trace "Advertiser loop and tasks stopped"
 
 proc new*(

--- a/archivist/discovery.nim
+++ b/archivist/discovery.nim
@@ -35,6 +35,10 @@ export discv5
 logScope:
   topics = "archivist discovery"
 
+const
+  DefaultDhtRefreshCooldown* = 5.seconds
+  DefaultDhtMinPeers* = BUCKET_SIZE
+
 type Discovery* = ref object of RootObj
   protocol*: discv5.Protocol # dht protocol
   key: PrivateKey # private key
@@ -44,6 +48,10 @@ type Discovery* = ref object of RootObj
     # record to advertice node connection information, this carry any
     # address that the node can be connected on
   dhtRecord*: ?SignedPeerRecord # record to advertice DHT connection information
+  lastDhtRefreshAt: Moment # Cooldown timestamp for dht refresh
+  refreshRoutingTableFut: Future[void].Raising([]) # Tracked background refresh task
+
+proc ensureDhtPopulated*(d: Discovery) {.gcsafe.}
 
 proc toNodeId*(cid: Cid): NodeId =
   ## Cid to discovery id
@@ -65,6 +73,7 @@ proc findPeer*(
   ##
 
   try:
+    d.ensureDhtPopulated()
     let node = await d.protocol.resolve(toNodeId(peerId))
 
     return
@@ -87,6 +96,7 @@ method find*(
   ##
 
   try:
+    d.ensureDhtPopulated()
     without providers =? (await d.protocol.getProviders(cid.toNodeId())).mapFailure,
       error:
       warn "Error finding providers for block", cid, error = error.msg
@@ -102,6 +112,7 @@ method provide*(d: Discovery, cid: Cid) {.async: (raises: [CancelledError]), bas
   ## Provide a block Cid
   ##
   try:
+    d.ensureDhtPopulated()
     let nodes = await d.protocol.addProvider(cid.toNodeId(), d.providerRecord.get)
 
     if nodes.len <= 0:
@@ -112,6 +123,44 @@ method provide*(d: Discovery, cid: Cid) {.async: (raises: [CancelledError]), bas
   except CatchableError as exc:
     warn "Error providing block", cid, exc = exc.msg
 
+proc nodesDiscovered*(d: Discovery): int =
+  if d.protocol.isNil:
+    return 0
+
+  d.protocol.nodesDiscovered()
+
+proc refreshRoutingTable*(
+    d: Discovery
+): Future[int] {.async: (raises: [CancelledError]).} =
+  if d.protocol.isNil:
+    return 0
+
+  try:
+    discard await d.protocol.queryRandom()
+  except CatchableError as exc:
+    trace "Routing table refresh failed", exc = exc.msg
+
+  d.nodesDiscovered()
+
+proc refreshRoutingTableBackground(d: Discovery) {.async: (raises: []).} =
+  try:
+    discard await d.refreshRoutingTable()
+  except CatchableError as exc:
+    trace "Background routing table refresh failed", exc = exc.msg
+
+proc ensureDhtPopulated*(d: Discovery) {.gcsafe.} =
+  if not d.refreshRoutingTableFut.isNil and not d.refreshRoutingTableFut.finished:
+    return
+
+  if (Moment.now() - d.lastDhtRefreshAt) < DefaultDhtRefreshCooldown:
+    return
+
+  if d.nodesDiscovered() >= DefaultDhtMinPeers:
+    return
+
+  d.lastDhtRefreshAt = Moment.now()
+  d.refreshRoutingTableFut = refreshRoutingTableBackground(d)
+
 method find*(
     d: Discovery, host: ca.Address
 ): Future[seq[SignedPeerRecord]] {.async: (raises: [CancelledError]), base.} =
@@ -120,6 +169,7 @@ method find*(
 
   try:
     trace "Finding providers for host", host = $host
+    d.ensureDhtPopulated()
     without var providers =? (await d.protocol.getProviders(host.toNodeId())).mapFailure,
       error:
       trace "Error finding providers for host", host = $host, exc = error.msg
@@ -147,6 +197,7 @@ method provide*(
 
   try:
     trace "Providing host", host = $host
+    d.ensureDhtPopulated()
     let nodes = await d.protocol.addProvider(host.toNodeId(), d.providerRecord.get)
     if nodes.len > 0:
       trace "Provided to nodes", nodes = nodes.len
@@ -205,6 +256,11 @@ proc start*(d: Discovery) {.async: (raises: []).} =
     error "Error starting discovery", exc = exc.msg
 
 proc stop*(d: Discovery) {.async: (raises: []).} =
+  if not d.refreshRoutingTableFut.isNil:
+    try:
+      await noCancel d.refreshRoutingTableFut.cancelAndWait()
+    except CatchableError as exc:
+      trace "Error cancelling background DHT refresh", exc = exc.msg
   if not d.protocol.isNil and not d.protocol.transport.isNil:
     try:
       await noCancel d.protocol.closeWait()

--- a/tests/archivist/blockexchange/discovery/testdiscovery.nim
+++ b/tests/archivist/blockexchange/discovery/testdiscovery.nim
@@ -76,7 +76,7 @@ suite "Block Advertising and Discovery":
       minPeersPerBlock = 1,
     )
 
-    advertiser = Advertiser.new(localStore, blockDiscovery)
+    advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
     engine = BlockExcEngine.new(
       localStore, network, discovery, advertiser, peerStore, pendingBlocks
@@ -222,7 +222,7 @@ suite "E2E - Multiple Nodes Discovery":
           minPeersPerBlock = 1,
         )
 
-        advertiser = Advertiser.new(localStore, blockDiscovery)
+        advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
         engine = BlockExcEngine.new(
           localStore, network, discovery, advertiser, peerStore, pendingBlocks

--- a/tests/archivist/blockexchange/engine/testadvertiser.nim
+++ b/tests/archivist/blockexchange/engine/testadvertiser.nim
@@ -44,7 +44,7 @@ asyncchecksuite "Advertiser":
     ) {.async: (raises: [CancelledError]), gcsafe.} =
       advertised.add(cid)
 
-    advertiser = Advertiser.new(localStore, blockDiscovery)
+    advertiser = Advertiser.new(localStore, blockDiscovery, minAdvertisePeers = 0)
 
     await advertiser.start()
 
@@ -99,7 +99,7 @@ asyncchecksuite "Advertiser":
     (await newStore.putBlock(manifestBlk)).tryGet()
 
     await advertiser.stop()
-    advertiser = Advertiser.new(newStore, blockDiscovery)
+    advertiser = Advertiser.new(newStore, blockDiscovery, minAdvertisePeers = 0)
     await advertiser.start()
 
     check eventually manifestBlk.cid in advertised

--- a/tests/archivist/blockexchange/engine/testblockexc.nim
+++ b/tests/archivist/blockexchange/engine/testblockexc.nim
@@ -2,6 +2,7 @@ import std/sequtils
 import std/algorithm
 
 import pkg/chronos
+import pkg/taskpools
 import pkg/stew/byteutils
 
 import pkg/archivist/stores
@@ -157,13 +158,15 @@ asyncchecksuite "NetworkStore engine - 2 nodes":
 
 asyncchecksuite "NetworkStore - multiple nodes":
   var
+    cluster: NodesCluster
     nodes: seq[NodesComponents]
     blocks: seq[bt.Block]
     manifest0, manifest1, manifest2, manifest3: Manifest
 
   setup:
     blocks = (await makeRandomBlocks(datasetSize = 4096, blockSize = 256'nb)).tryGet
-    nodes = generateNodes(5)
+    cluster = generateNodes(5)
+    nodes = cluster.components
 
     # Store blocks as trees on each source node (4 blocks per node)
     manifest0 =
@@ -191,8 +194,12 @@ asyncchecksuite "NetworkStore - multiple nodes":
     await allFuturesThrowing(nodes.mapIt(it.switch.start()))
 
   teardown:
+    await allFuturesThrowing(nodes.mapIt(it.engine.stop()))
+    await allFuturesThrowing(nodes.mapIt(it.blockDiscovery.stop()))
     await allFuturesThrowing(nodes.mapIt(it.switch.stop()))
-
+    await allFuturesThrowing(nodes.mapIt(it.localStore.close()))
+    if not cluster.isNil and not cluster.taskpool.isNil:
+      cluster.taskpool.shutdown()
     nodes = @[]
 
   test "Should receive blocks for own want list":

--- a/tests/archivist/node/tempnode.nim
+++ b/tests/archivist/node/tempnode.nim
@@ -13,6 +13,7 @@ import pkg/archivist/systemclock
 type TemporaryNode* = ref object
   repoDs: KVStore
   metaDs: KVStore
+  discoveryDs: KVStore
   tp: Taskpool
   localStore: RepoStore
   p2p: Switch
@@ -38,9 +39,9 @@ proc initializeNetwork(temporary: TemporaryNode) =
   temporary.exchangeNetwork = BlockExcnetwork.new(temporary.p2p)
   let privateKey = temporary.p2p.peerInfo.privateKey
   let address = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet()
-  let discoveryDs = SQLiteKVStore.new(SqliteMemory, temporary.tp).tryGet()
+  temporary.discoveryDs = SQLiteKVStore.new(SqliteMemory, temporary.tp).tryGet()
   temporary.discoveryNetwork =
-    Discovery.new(privateKey, announceAddrs = @[address], store = discoveryDs)
+    Discovery.new(privateKey, announceAddrs = @[address], store = temporary.discoveryDs)
 
 proc initializePendingBlocks(temporary: TemporaryNode) =
   temporary.pendingBlocks = PendingBlocksManager.new()
@@ -90,6 +91,7 @@ proc destroy*(temporary: TemporaryNode) {.async.} =
   await temporary.node.stop()
   (await temporary.repoDs.close()).tryGet()
   (await temporary.metaDs.close()).tryGet()
+  (await temporary.discoveryDs.close()).tryGet()
   temporary.tp.shutdown()
 
 func node*(temporary: TemporaryNode): ArchivistNodeRef =


### PR DESCRIPTION
This addresses low number of peers in the dht by running random walks and re-queuing advertisements, downloads also trigger random walks, but the re-queueing is handled by the block scheduling pipeline.