### PR TITLE
make background batch fetchBatched randommized

### DIFF
--- a/archivist/node.nim
+++ b/archivist/node.nim
@@ -32,6 +32,7 @@ import pkg/libp2p/signed_envelope
 
 import ./metrics
 import ./chunker
+import ./archivisttypes
 import ./slots
 import ./clock
 import ./blocktype as bt
@@ -50,6 +51,7 @@ import ./logutils
 import ./utils/asynciter
 import ./utils/trackedfutures
 import ./utils/poseidon2digest
+import ./rng
 
 export logutils
 
@@ -58,8 +60,14 @@ logScope:
 
 const
   DefaultFetchBatch = 128
+  DefaultFetchPrefetch = 2 ## In-flight fetch batches (pipeline depth)
   DefaultStoreBatch* = 1024 ## Number of blocks to batch when storing data
   MaxInFlightBatches = 4 ## Maximum concurrent batch flushes for bounded parallelism
+
+type FetchOrder* {.pure.} = enum
+  Linear = "linear" ## iterate block indices 0 ..< count (stream-friendly default)
+  RandomizedCircular = "randomized-circular"
+    ## iterate circularly from a random linear start point
 
 type
   ArchivistNode* = object
@@ -189,9 +197,16 @@ proc fetchBatched*(
     batchSize = DefaultFetchBatch,
     onBatch: BatchProc = nil,
     fetchLocal = true,
+    prefetch = DefaultFetchPrefetch,
 ): Future[?!void] {.async: (raises: [CancelledError]), gcsafe.} =
   ## Fetch blocks in batches of `batchSize`
   ##
+  ## Keeps up to `prefetch` batch fetches in flight so the network fetch for
+  ## batch N+1 overlaps consumption of batch N. prefetch=1 restores the old
+  ## stop-and-wait behavior.
+  ##
+
+  let prefetch = max(1, prefetch)
 
   await self.repoStore.withOverlay(
     cid,
@@ -207,7 +222,7 @@ proc fetchBatched*(
         else:
           BitSeq.init(0)
 
-      while not iter.finished:
+      proc collectBatch(): seq[Natural] =
         var batchIndices: seq[Natural]
         for i in 0 ..< batchSize:
           if not iter.finished:
@@ -215,19 +230,43 @@ proc fetchBatched*(
             # Include index if fetchLocal is set, or if it's not yet in the bitmap
             if fetchLocal or idx >= bits.len or not bits[idx]:
               batchIndices.add(idx.Natural)
+        batchIndices
 
-        if batchIndices.len == 0:
-          continue
+      var inFlight:
+        seq[(int, Future[?!seq[(Natural, bt.Block)]].Raising([CancelledError]))]
 
-        without blocks =? (await self.networkStore.getBlocks(cid, batchIndices)), err:
+      defer:
+        for (_, fut) in inFlight:
+          await noCancel fut.cancelAndWait()
+
+      proc fillWindow() =
+        while inFlight.len < prefetch and not iter.finished:
+          let batchIndices = collectBatch()
+          if batchIndices.len == 0:
+            continue
+          inFlight.add(
+            (batchIndices.len, self.networkStore.getBlocks(cid, batchIndices))
+          )
+
+      fillWindow()
+      while inFlight.len > 0:
+        # Await via inFlight[0] (not a popped copy) so that cancelling this
+        # proc mid-await still lets the defer below cancel the current batch.
+        let expected = inFlight[0][0]
+
+        without blocks =? (await inFlight[0][1]), err:
           trace "Some blocks failed to fetch", err = err.msg
           return failure(err)
 
-        if blocks.len != batchIndices.len:
+        if blocks.len != expected:
           return failure(
-            "Some blocks failed to fetch (" & $(batchIndices.len - blocks.len) &
-              " missing)"
+            "Some blocks failed to fetch (" & $(expected - blocks.len) & " missing)"
           )
+
+        inFlight.delete(0)
+
+        # Refill before consuming so the next fetch overlaps streaming out
+        fillWindow()
 
         if not onBatch.isNil and
             batchErr =? (await onBatch(blocks.mapIt(it[1]))).errorOption:
@@ -242,15 +281,31 @@ proc fetchBatched*(
     batchSize = DefaultFetchBatch,
     onBatch: BatchProc = nil,
     fetchLocal = true,
+    prefetch = DefaultFetchPrefetch,
+    fetchOrder: FetchOrder,
 ): Future[?!void] {.async: (raw: true, raises: [CancelledError]).} =
   ## Fetch manifest in batches of `batchSize`
   ##
+  ## With FetchOrder.RandomizedCircular, block indices are iterated
+  ## circularly from a random linear start point instead of always from
+  ## index 0, so concurrent downloaders of the same dataset work on
+  ## different regions and can re-serve blocks to each other.
+  ##
+
+  let
+    count = manifest.blocksCount
+    randomized = fetchOrder == FetchOrder.RandomizedCircular and count > 0
+    start =
+      if randomized:
+        Rng.instance.rand(count - 1)
+      else:
+        0
+    iter = Iter[int].new(0 ..< count, start)
 
   trace "Fetching blocks in batches of",
-    size = batchSize, blocksCount = manifest.blocksCount
+    size = batchSize, blocksCount = count, fetchOrder = $fetchOrder, start = start
 
-  let iter = Iter[int].new(0 ..< manifest.blocksCount)
-  self.fetchBatched(manifest.treeCid, iter, batchSize, onBatch, fetchLocal)
+  self.fetchBatched(manifest.treeCid, iter, batchSize, onBatch, fetchLocal, prefetch)
 
 proc fetchDatasetAsync*(
     self: ArchivistNodeRef, manifest: Manifest, fetchLocal = true
@@ -261,7 +316,10 @@ proc fetchDatasetAsync*(
   try:
     if err =? (
       await self.fetchBatched(
-        manifest = manifest, batchSize = DefaultFetchBatch, fetchLocal = fetchLocal
+        manifest = manifest,
+        batchSize = DefaultFetchBatch,
+        fetchLocal = fetchLocal,
+        fetchOrder = FetchOrder.RandomizedCircular,
       )
     ).errorOption:
       error "Unable to fetch blocks", err = err.msg
@@ -276,7 +334,10 @@ proc fetchDatasetAsyncTask*(self: ArchivistNodeRef, manifest: Manifest) =
     try:
       if err =? (
         await self.fetchBatched(
-          manifest = manifest, batchSize = DefaultFetchBatch, fetchLocal = false
+          manifest = manifest,
+          batchSize = DefaultFetchBatch,
+          fetchLocal = false,
+          fetchOrder = FetchOrder.RandomizedCircular,
         )
       ).errorOption:
         error "Unable to fetch dataset", err = err.msg
@@ -342,7 +403,10 @@ proc streamEntireDataset(
       try:
         if err =? (
           await self.fetchBatched(
-            manifest = manifest, batchSize = DefaultFetchBatch, fetchLocal = false
+            manifest = manifest,
+            batchSize = DefaultFetchBatch,
+            fetchLocal = false,
+            fetchOrder = FetchOrder.Linear,
           )
         ).errorOption:
           error "Unable to fetch blocks", err = err.msg
@@ -1005,6 +1069,10 @@ proc new*(
     marketplace = MarketplaceNode.none,
 ): ArchivistNodeRef =
   ## Create new instance of a node, call `start` to run it
+  ##
+  ## Background downloads (fetchDatasetAsync/fetchDatasetAsyncTask) use
+  ## RandomizedCircular so concurrent downloaders of the same dataset work
+  ## on different regions; streaming retrieves always use Linear.
   ##
 
   ArchivistNodeRef(

--- a/archivist/utils/iter.nim
+++ b/archivist/utils/iter.nim
@@ -139,6 +139,43 @@ proc new*[U, V: Ordinal](_: type Iter[U], slice: HSlice[U, V]): Iter[U] =
 
   Iter[U].new(slice.a.int, slice.b.int, 1)
 
+proc new*(T: type Iter[int], slice: HSlice[int, int], start: int): Iter[int] =
+  ## Creates a circular Iter from an int slice, starting at `start` and
+  ## wrapping around to the slice's first element after reaching its last.
+  ## Every element of the slice is yielded exactly once. `start` must lie
+  ## within the slice.
+  ##
+
+  var
+    i = start
+    wrapped = false
+    disposed = false
+
+  let
+    a = slice.a
+    b = slice.b
+
+  doAssert (i >= a and i <= b) or a > b, "start must lie within the slice"
+
+  proc genNext(): int =
+    let u = i
+    inc(i)
+    if i > b:
+      i = a
+      wrapped = true
+    u
+
+  proc isFinished(): bool =
+    a > b or (wrapped and i >= start)
+
+  proc onDispose() =
+    disposed = true
+
+  proc isDisposed(): bool =
+    disposed
+
+  T.new(genNext, isFinished, onDispose, isDisposed)
+
 proc new*[T](_: type Iter[T], items: seq[T]): Iter[T] =
   ## Creates a new Iter from a sequence
   ##

--- a/tests/archivist/node/testnode.nim
+++ b/tests/archivist/node/testnode.nim
@@ -1,6 +1,7 @@
 import std/os
 import std/options
 import std/math
+import std/sequtils
 
 import pkg/chronos
 import pkg/stew/byteutils
@@ -129,6 +130,7 @@ suite "Test Node - Basic":
           ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
             check blocks.len > 0 and blocks.len <= batchSize
             return success(),
+          fetchOrder = FetchOrder.RandomizedCircular,
         )
       ).tryGet()
 
@@ -150,13 +152,124 @@ suite "Test Node - Basic":
       await node.fetchBatched(
         manifest,
         batchSize = batchSize,
-        proc(
+        onBatch = proc(
             blocks: seq[bt.Block]
         ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
           return failure("Should not be called"),
+        fetchOrder = FetchOrder.RandomizedCircular,
       )
     )
     check res.isFailure
+
+  test "Fetch pipeline prefetch window delivers every block exactly once":
+    let
+      blocks =
+        (await makeRandomBlocks(datasetSize = 512.KiBs.int, blockSize = 64.KiBs)).tryGet
+      manifest = (await storeDataGetManifest(localStore, blocks)).tryGet
+
+    var fetched: seq[bt.Block]
+
+    (
+      await node.fetchBatched(
+        manifest,
+        batchSize = 2,
+        onBatch = proc(
+            batch: seq[bt.Block]
+        ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+          fetched.add(batch)
+          return success(),
+        prefetch = 4,
+        fetchOrder = FetchOrder.RandomizedCircular,
+      )
+    ).tryGet
+
+    check fetched.len == blocks.len
+    for blk in blocks:
+      check fetched.filterIt(it.cid == blk.cid).len == 1
+
+  test "Fetch with fetchLocal=false skips already-present blocks":
+    let
+      blocks =
+        (await makeRandomBlocks(datasetSize = 512.KiBs.int, blockSize = 64.KiBs)).tryGet
+      manifest = (await storeDataGetManifest(localStore, blocks)).tryGet
+
+    var onBatchCalled = false
+
+    (
+      await node.fetchBatched(
+        manifest,
+        batchSize = 2,
+        fetchLocal = false,
+        onBatch = proc(
+            batch: seq[bt.Block]
+        ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+          onBatchCalled = true
+          return success(),
+        fetchOrder = FetchOrder.RandomizedCircular,
+      )
+    ).tryGet
+
+    check not onBatchCalled
+
+  test "Randomized circular fetch order starts at a random index":
+    let
+      blocks =
+        (await makeRandomBlocks(datasetSize = 512.KiBs.int, blockSize = 64.KiBs)).tryGet
+      manifest = (await storeDataGetManifest(localStore, blocks)).tryGet
+
+    # With batchSize=1 the first delivered block is the iteration start.
+    # Over repeated runs the start must be non-zero at least once; the
+    # probability of drawing start=0 on every run is (1/blocks.len)^runs.
+    var startedOffZero = false
+    for _ in 0 ..< 16:
+      var firstBatch: seq[bt.Block]
+
+      (
+        await node.fetchBatched(
+          manifest,
+          batchSize = 1,
+          onBatch = proc(
+              batch: seq[bt.Block]
+          ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+            if firstBatch.len == 0:
+              firstBatch = batch
+            return success(),
+          fetchOrder = FetchOrder.RandomizedCircular,
+        )
+      ).tryGet
+      if firstBatch.len > 0 and firstBatch[0].cid != blocks[0].cid:
+        startedOffZero = true
+        break
+
+    check startedOffZero
+
+  test "Fetch with circular iter covers all indices exactly once":
+    let
+      blocks =
+        (await makeRandomBlocks(datasetSize = 512.KiBs.int, blockSize = 64.KiBs)).tryGet
+      manifest = (await storeDataGetManifest(localStore, blocks)).tryGet
+
+    let start = 3
+    let iter = Iter[int].new(0 ..< manifest.blocksCount, start)
+
+    var fetched: seq[bt.Block]
+
+    (
+      await node.fetchBatched(
+        manifest.treeCid,
+        iter,
+        batchSize = 2,
+        onBatch = proc(
+            batch: seq[bt.Block]
+        ): Future[?!void] {.gcsafe, async: (raises: [CancelledError]).} =
+          fetched.add(batch)
+          return success(),
+      )
+    ).tryGet
+
+    check fetched.len == blocks.len
+    for blk in blocks:
+      check fetched.filterIt(it.cid == blk.cid).len == 1
 
   test "Should store Data Stream":
     let

--- a/tests/archivist/utils/testiter.nim
+++ b/tests/archivist/utils/testiter.nim
@@ -1,3 +1,4 @@
+import std/algorithm
 import std/sugar
 
 import pkg/questionable
@@ -120,3 +121,46 @@ suite "Test Iter":
     check:
       collected == @["0", "1", "2"]
       iter2.finished
+
+  test "Circular iter should yield nothing for an empty range":
+    let iter = Iter[int].new(0 ..< 0, 0)
+
+    check:
+      iter.toSeq() == newSeq[int]()
+      iter.finished
+
+  test "Circular iter should yield a single element once":
+    let iter = Iter[int].new(0 ..< 1, 0)
+
+    check:
+      iter.toSeq() == @[0]
+      iter.finished
+
+  test "Circular iter should start at `start` and wrap around":
+    let iter = Iter[int].new(0 ..< 5, 3)
+
+    check:
+      iter.toSeq() == @[3, 4, 0, 1, 2]
+      iter.finished
+
+  test "Circular iter should wrap when starting at the last element":
+    let iter = Iter[int].new(0 ..< 5, 4)
+
+    check:
+      iter.toSeq() == @[4, 0, 1, 2, 3]
+      iter.finished
+
+  test "Circular iter should wrap to the slice's first element":
+    let iter = Iter[int].new(2 .. 6, 4)
+
+    check:
+      iter.toSeq() == @[4, 5, 6, 2, 3]
+      iter.finished
+
+  test "Circular iter should yield every index exactly once from any start":
+    for start in 0 ..< 5:
+      let items = Iter[int].new(0 ..< 5, start).toSeq()
+
+      check:
+        items.len == 5
+        items.sorted == @[0, 1, 2, 3, 4]


### PR DESCRIPTION
this allows spreading the chunks across more nodes in the network and avoids bottlenecking the uploader